### PR TITLE
fix: downgrade frequent info msg

### DIFF
--- a/toolkit/bridge/primitives/src/lib.rs
+++ b/toolkit/bridge/primitives/src/lib.rs
@@ -422,7 +422,7 @@ impl<RecipientAddress: Encode + Send + Sync> TokenBridgeInherentDataProvider<Rec
 		let (Some(last_checkpoint), Some(main_chain_scripts)) =
 			(api.get_last_data_checkpoint(parent_hash)?, api.get_main_chain_scripts(parent_hash)?)
 		else {
-			log::info!("💤 Skipping token bridge transfer observation. Pallet not configured.");
+			log::debug!("💤 Skipping token bridge transfer observation. Pallet not configured.");
 			return Ok(Self::Inert);
 		};
 


### PR DESCRIPTION
# Description

Downgrade "Skipping token bridge transfer observation" log from `info` to `debug` in `toolkit/bridge/primitives/src/lib.rs`. This message fires frequently when the bridge pallet isn't configured and clutters node logs at the default log level.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] The size limit of 400 LOC isn't needlessly exceeded
- [ ] The PR refers to a JIRA ticket (if one exists)
- [x] New tests are added if needed and existing tests are updated.
- [x] New code is documented and existing documentation is updated.
- [x] Relevant logging and metrics added
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff