### PR TITLE
  fix: apply block_stability_margin to verifier-side depth check

### DIFF
--- a/toolkit/data-sources/db-sync/src/block/mod.rs
+++ b/toolkit/data-sources/db-sync/src/block/mod.rs
@@ -255,7 +255,7 @@ impl BlockDataSourceImpl {
 		Ok(block
 			.zip(latest_block)
 			.filter(|(block, latest_block)| {
-				block.block_no.saturating_add(self.security_parameter) <= latest_block.block_no
+				block.block_no.saturating_add(self.security_parameter) <= latest_block.block_no.saturating_add(self.block_stability_margin)
 					&& self.is_block_time_valid(block, reference_timestamp)
 			})
 			.map(|(block, _)| block))


### PR DESCRIPTION
  The block_stability_margin was only used on the author side when
  selecting a stable Cardano block (tip - security_parameter - margin),
  but the verifier side checked depth using only security_parameter
  (block + security_parameter <= tip). This meant the margin only
  provided indirect tolerance for db-sync lag between author and
  verifier nodes.

  Apply the margin on the verifier side as well, so the check becomes:
  block + security_parameter <= tip + margin

  This doubles the effective db-sync lag tolerance from margin to
  2*margin blocks, making block verification more resilient to
  temporary db-sync delays without meaningfully reducing security.

# Description

Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] The size limit of 400 LOC isn't needlessly exceeded
- [ ] The PR refers to a JIRA ticket (if one exists)
- [ ] New tests are added if needed and existing tests are updated.
- [ ] New code is documented and existing documentation is updated.
- [ ] Relevant logging and metrics added
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff
