### PR TITLE
C to M bridge on metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2321,6 +2321,7 @@ dependencies = [
 name = "db-sync-sqlx"
 version = "1.8.1"
 dependencies = [
+ "hex",
  "num-traits",
  "sidechain-domain",
  "sqlx",

--- a/demo/node/src/staging.rs
+++ b/demo/node/src/staging.rs
@@ -157,7 +157,7 @@ pub fn staging_genesis(
 		},
 		bridge: BridgeConfig {
 			main_chain_scripts: Some(sp_partner_chains_bridge::MainChainScripts::read_from_env()?),
-			initial_checkpoint: Some(genesis_utxo),
+			initial_checkpoint: Some(genesis_utxo.tx_hash),
 			..Default::default()
 		},
 	};

--- a/demo/node/src/template_chain_spec.rs
+++ b/demo/node/src/template_chain_spec.rs
@@ -47,7 +47,7 @@ pub fn chain_spec() -> Result<ChainSpec, envy::Error> {
 		},
 		bridge: BridgeConfig {
 			main_chain_scripts: Some(sp_partner_chains_bridge::MainChainScripts::read_from_env()?),
-			initial_checkpoint: Some(genesis_utxo),
+			initial_checkpoint: Some(genesis_utxo.tx_hash),
 			..Default::default()
 		},
 	};

--- a/demo/node/src/testnet.rs
+++ b/demo/node/src/testnet.rs
@@ -212,7 +212,7 @@ pub fn testnet_genesis(
 		},
 		bridge: BridgeConfig {
 			main_chain_scripts: Some(sp_partner_chains_bridge::MainChainScripts::read_from_env()?),
-			initial_checkpoint: Some(genesis_utxo),
+			initial_checkpoint: Some(genesis_utxo.tx_hash),
 			..Default::default()
 		},
 	};

--- a/demo/node/src/tests/chain_spec.rs
+++ b/demo/node/src/tests/chain_spec.rs
@@ -48,7 +48,7 @@ fn pc_create_chain_spec_test() {
 	assert_eq!(
 		config_obj.get("bridge").unwrap(),
 		&serde_json::json!({
-		  "initialCheckpoint": "0101010101010101010101010101010101010101010101010101010101010101#7",
+		  "initialCheckpoint": "0x0101010101010101010101010101010101010101010101010101010101010101",
 		  "mainChainScripts": {
 			"token_policy_id": "0x04040404040404040404040404040404040404040404040404040404",
 			"token_asset_name": "0x040404",

--- a/demo/runtime/src/test_helper_pallet.rs
+++ b/demo/runtime/src/test_helper_pallet.rs
@@ -131,10 +131,8 @@ pub mod pallet {
 	impl<T: Config> pallet_partner_chains_bridge::TransferHandler<AccountId> for Pallet<T> {
 		fn handle_incoming_transfer(transfer: BridgeTransferV1<AccountId>) {
 			match transfer {
-				BridgeTransferV1::InvalidTransfer { token_amount, utxo_id } => {
-					log::warn!(
-						"⚠️ Recorded an invalid transfer of {token_amount} (utxo {utxo_id})"
-					);
+				BridgeTransferV1::InvalidTransfer { token_amount, tx_hash } => {
+					log::warn!("⚠️ Recorded an invalid transfer of {token_amount} (tx {tx_hash})");
 					TotalInvalidTransfers::<T>::mutate(|v| *v + token_amount);
 				},
 				BridgeTransferV1::UserTransfer { token_amount, recipient } => {

--- a/toolkit/bridge/pallet/src/benchmarking.rs
+++ b/toolkit/bridge/pallet/src/benchmarking.rs
@@ -2,7 +2,7 @@ use super::*;
 use frame_benchmarking::v2::*;
 use frame_support::{BoundedVec, assert_ok, traits::Get};
 use frame_system::RawOrigin;
-use sidechain_domain::{McBlockNumber, UtxoId};
+use sidechain_domain::{McBlockNumber, McTxHash};
 use sp_core::{H256, crypto::UncheckedFrom};
 use sp_partner_chains_bridge::*;
 
@@ -28,12 +28,12 @@ where
 		use BridgeTransferV1::*;
 
 		let recipient = T::Recipient::unchecked_from(Default::default());
-		let utxo_id = UtxoId::default();
+		let tx_hash = McTxHash::default();
 
 		let transfers = alloc::vec![
 			UserTransfer { token_amount: 1000, recipient },
 			ReserveTransfer { token_amount: 1000 },
-			InvalidTransfer { token_amount: 1000, utxo_id },
+			InvalidTransfer { token_amount: 1000, tx_hash },
 		]
 		.into_iter()
 		.cycle()

--- a/toolkit/bridge/pallet/src/lib.rs
+++ b/toolkit/bridge/pallet/src/lib.rs
@@ -262,8 +262,6 @@ pub mod pallet {
 	pub enum Error<T> {
 		/// Only one inherent call per block is allowed
 		InherentAlreadyExecuted,
-		/// Too many transactions to handle
-		TooManyUtxos,
 	}
 
 	#[pallet::storage]

--- a/toolkit/bridge/pallet/src/lib.rs
+++ b/toolkit/bridge/pallet/src/lib.rs
@@ -192,6 +192,7 @@ pub mod benchmarking;
 /// Weight types and default weight values
 pub mod weights;
 
+use frame_support::pallet_prelude::*;
 pub use pallet::*;
 use sp_partner_chains_bridge::BridgeTransferV1;
 
@@ -215,8 +216,10 @@ impl<Recipient> TransferHandler<Recipient> for () {
 pub mod pallet {
 	use super::*;
 	use crate::weights::WeightInfo;
-	use frame_support::pallet_prelude::*;
-	use frame_system::{ensure_none, pallet_prelude::OriginFor};
+	use frame_system::{
+		ensure_none,
+		pallet_prelude::{BlockNumberFor, OriginFor},
+	};
 	use parity_scale_codec::MaxEncodedLen;
 	use sidechain_domain::McTxHash;
 	use sp_partner_chains_bridge::{
@@ -256,7 +259,12 @@ pub mod pallet {
 
 	/// Error type used by the pallet's extrinsics
 	#[pallet::error]
-	pub enum Error<T> {}
+	pub enum Error<T> {
+		/// Only one inherent call per block is allowed
+		InherentAlreadyExecuted,
+		/// Too many transactions to handle
+		TooManyUtxos,
+	}
 
 	#[pallet::storage]
 	pub type MainChainScriptsConfiguration<T: Config> =
@@ -264,6 +272,9 @@ pub mod pallet {
 
 	#[pallet::storage]
 	pub type DataCheckpoint<T: Config> = StorageValue<_, BridgeDataCheckpoint, OptionQuery>;
+
+	#[pallet::storage]
+	pub type InherentExecutedThisBlock<T: Config> = StorageValue<_, bool, ValueQuery>;
 
 	/// Genesis configuration of the pallet
 	#[pallet::genesis_config]
@@ -290,6 +301,18 @@ pub mod pallet {
 		}
 	}
 
+	#[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+		fn on_initialize(_n: BlockNumberFor<T>) -> Weight {
+			// Pre-account for on_finalize weight (storage write to reset inherent flag)
+			T::DbWeight::get().writes(1)
+		}
+
+		fn on_finalize(_n: BlockNumberFor<T>) {
+			InherentExecutedThisBlock::<T>::kill();
+		}
+	}
+
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
 		/// Inherent extrinsic that handles all incoming transfers in the current block
@@ -301,6 +324,8 @@ pub mod pallet {
 			data_checkpoint: BridgeDataCheckpoint,
 		) -> DispatchResult {
 			ensure_none(origin)?;
+			ensure!(!InherentExecutedThisBlock::<T>::get(), Error::<T>::InherentAlreadyExecuted);
+			InherentExecutedThisBlock::<T>::put(true);
 			for transfer in transfers {
 				T::TransferHandler::handle_incoming_transfer(transfer);
 			}

--- a/toolkit/bridge/pallet/src/lib.rs
+++ b/toolkit/bridge/pallet/src/lib.rs
@@ -10,13 +10,16 @@
 //! # Working overview
 //!
 //! Bridge transfers are initiated by transactions on Cardano that create UTXOs
-//! on the illiquid circulating supply (ICP) validator address, each containing
-//! a datum which marks them as transfer UTXOs. The observability layer of a
-//! Partner Chain node registers creation of these UTXOs and classifies them
-//! either as *user transfers*, ie. transfers sent by normal chain users to a
-//! Partner Chain address specified by the user; or special *reserve transfers*,
-//! which are a mechanism for a Partner Chain to gradually move their token
-//! reserve from Cardano to its own ledger.
+//! on the illiquid circulating supply (ICP) validator address. The observability
+//! layer of a Partner Chain node registers these transactions and classifies them
+//! based on the metadata attached to the transaction as one of the following types:
+//! - *user transfers*, ie. transfers sent by normal chain users to a
+//!   Partner Chain address specified by the user,
+//! - *reserve transfers*, which are a mechanism for a Partner Chain to gradually
+//!   move their token reserve from Cardano to its own ledger,
+//! - *invalid transfers*, which are all transactions that have deposited some native
+//!   tokens into ICP but can not be classified due to invalid metadata. These transfers
+//!   are still processed in order for them to be accounted for and possibly recovered.
 //!
 //! Newly observed and classified bridge transfers are provided to the runtime
 //! as inherent data. Based on this data, the pallet creates an inherent
@@ -30,9 +33,9 @@
 //!
 //! ## Define the recipient type
 //!
-//! All user transfers handler by the pallet are addressed to a recipient
-//! specified in the datum of the transfer UTXO. This recipient can be any
-//! type that can be encoded and decoded as a Plutus byte string. A natural
+//! All user transfers handled by the pallet are addressed to a recipient
+//! specified in the transaction's metadata. This recipient can be any
+//! type that can be encoded and decoded as a byte string. A natural
 //! choice would be the account address used in the Partner Chain runtime,
 //! but a different type can be chosen as needed.
 //!
@@ -215,7 +218,7 @@ pub mod pallet {
 	use frame_support::pallet_prelude::*;
 	use frame_system::{ensure_none, pallet_prelude::OriginFor};
 	use parity_scale_codec::MaxEncodedLen;
-	use sidechain_domain::UtxoId;
+	use sidechain_domain::McTxHash;
 	use sp_partner_chains_bridge::{
 		BridgeDataCheckpoint, INHERENT_IDENTIFIER, InherentError, MainChainScripts,
 		TokenBridgeTransfersV1,
@@ -268,7 +271,7 @@ pub mod pallet {
 		/// Initial main chain scripts
 		pub main_chain_scripts: Option<MainChainScripts>,
 		/// The initial data checkpoint. Chain Genesis UTXO is a good candidate for it.
-		pub initial_checkpoint: Option<UtxoId>,
+		pub initial_checkpoint: Option<McTxHash>,
 		#[allow(missing_docs)]
 		pub _marker: PhantomData<T>,
 	}
@@ -283,7 +286,7 @@ pub mod pallet {
 	impl<T: Config> BuildGenesisConfig for GenesisConfig<T> {
 		fn build(&self) {
 			MainChainScriptsConfiguration::<T>::set(self.main_chain_scripts.clone());
-			DataCheckpoint::<T>::set(self.initial_checkpoint.map(BridgeDataCheckpoint::Utxo));
+			DataCheckpoint::<T>::set(self.initial_checkpoint.map(BridgeDataCheckpoint::Tx));
 		}
 	}
 

--- a/toolkit/bridge/pallet/src/tests.rs
+++ b/toolkit/bridge/pallet/src/tests.rs
@@ -7,7 +7,7 @@ use frame_support::{
 	assert_err, assert_ok,
 	inherent::{InherentData, ProvideInherent},
 };
-use sidechain_domain::{AssetName, MainchainAddress, PolicyId, UtxoId};
+use sidechain_domain::{AssetName, MainchainAddress, McTxHash, PolicyId};
 use sp_core::bounded_vec;
 use sp_partner_chains_bridge::*;
 use sp_runtime::{AccountId32, BoundedVec};
@@ -16,7 +16,7 @@ fn transfers() -> BoundedVec<BridgeTransferV1<RecipientAddress>, MaxTransfersPer
 	bounded_vec![
 		UserTransfer { token_amount: 100, recipient: AccountId32::new([2; 32]) },
 		ReserveTransfer { token_amount: 200 },
-		InvalidTransfer { token_amount: 300, utxo_id: UtxoId::new([1; 32], 1) }
+		InvalidTransfer { token_amount: 300, tx_hash: McTxHash([1; 32]) }
 	]
 }
 
@@ -32,7 +32,7 @@ fn main_chain_scripts() -> MainChainScripts {
 }
 
 fn data_checkpoint() -> BridgeDataCheckpoint {
-	BridgeDataCheckpoint::Utxo(UtxoId::new([1; 32], 3))
+	BridgeDataCheckpoint::Tx(McTxHash([1; 32]))
 }
 
 mod set_main_chain_scripts {

--- a/toolkit/bridge/primitives/src/lib.rs
+++ b/toolkit/bridge/primitives/src/lib.rs
@@ -128,7 +128,7 @@ use parity_scale_codec::{Decode, DecodeWithMemTracking, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
 use sidechain_domain::{
-	AssetId, AssetName, MainchainAddress, McBlockHash, McBlockNumber, PolicyId, UtxoId,
+	AssetId, AssetName, MainchainAddress, McBlockHash, McBlockNumber, McTxHash, PolicyId,
 };
 use sp_inherents::*;
 
@@ -219,14 +219,14 @@ pub enum BridgeTransferV1<RecipientAddress> {
 		/// Amount of tokens tranfered
 		token_amount: u64,
 	},
-	/// Invalid transfer coming from a UTXO on Cardano that does not contain a datum that can be
+	/// Invalid transfer coming from a Transaction on Cardano that does not contain a metadata that can be
 	/// correctly interpreted. These transfers can either be ignored and considered lost or recovered
 	/// through some custom mechanism.
 	InvalidTransfer {
 		/// Amount of tokens tranfered
 		token_amount: u64,
 		/// ID of the UTXO containing an invalid transfer
-		utxo_id: sidechain_domain::UtxoId,
+		tx_hash: sidechain_domain::McTxHash,
 	},
 }
 
@@ -286,8 +286,8 @@ pub enum TokenBridgeInherentDataProvider<RecipientAddress> {
 	Clone, Debug, Encode, Decode, DecodeWithMemTracking, TypeInfo, PartialEq, Eq, MaxEncodedLen,
 )]
 pub enum BridgeDataCheckpoint {
-	/// Last transfer utxo that has been processed
-	Utxo(UtxoId),
+	/// The last transaction that has been processed
+	Tx(McTxHash),
 	/// Cardano block up to which data has been processed
 	Block(McBlockNumber),
 }

--- a/toolkit/data-sources/db-sync/src/bridge/cache.rs
+++ b/toolkit/data-sources/db-sync/src/bridge/cache.rs
@@ -1,8 +1,8 @@
 use super::*;
 use crate::BlockDataSourceImpl;
-use crate::db_model::BridgeUtxo;
+use crate::db_model::BridgeTx;
 use futures::lock::Mutex;
-use sidechain_domain::{MainchainBlock, McBlockHash, UtxoId};
+use sidechain_domain::{MainchainBlock, McBlockHash, McTxHash};
 use std::{cmp::min, collections::HashMap, error::Error, sync::Arc};
 
 /// Bridge transfer data source with block range-based caching
@@ -35,8 +35,8 @@ pub(crate) struct TokenUtxoCache {
 	mc_scripts: MainChainScripts,
 	start_block: BlockNumber,
 	end_block: BlockNumber,
-	transfers: Vec<BridgeUtxo>,
-	utxo_cache: HashMap<UtxoId, BridgeUtxo>,
+	transfers: Vec<BridgeTx>,
+	tx_cache: HashMap<McTxHash, BridgeTx>,
 }
 
 impl TokenUtxoCache {
@@ -57,11 +57,11 @@ impl TokenUtxoCache {
 		&mut self,
 		start_block: BlockNumber,
 		end_block: BlockNumber,
-		transfers: Vec<BridgeUtxo>,
+		transfers: Vec<BridgeTx>,
 	) {
 		self.start_block = start_block;
 		self.end_block = end_block;
-		self.utxo_cache = transfers.iter().map(|utxo| (utxo.utxo_id(), utxo.clone())).collect();
+		self.tx_cache = transfers.iter().map(|tx| (tx.tx_id(), tx.clone())).collect();
 		self.transfers = transfers;
 	}
 
@@ -70,21 +70,21 @@ impl TokenUtxoCache {
 		checkpoint: &ResolvedBridgeDataCheckpoint,
 		to_block: BlockNumber,
 		max_transfers: u32,
-	) -> Option<Vec<BridgeUtxo>> {
+	) -> Option<Vec<BridgeTx>> {
 		if self.end_block < to_block {
 			return None;
 		}
 
-		let skip_pred: Box<dyn FnMut(&&BridgeUtxo) -> bool> = match checkpoint {
+		let skip_pred: Box<dyn FnMut(&&BridgeTx) -> bool> = match checkpoint {
 			ResolvedBridgeDataCheckpoint::Block { number }
 				if self.start_block <= number.saturating_add(1u32) =>
 			{
 				Box::new(move |utxo| *number >= utxo.block_number)
 			},
-			ResolvedBridgeDataCheckpoint::Utxo { block_number, tx_ix, tx_out_ix }
+			ResolvedBridgeDataCheckpoint::Tx { block_number, tx_ix }
 				if self.start_block <= *block_number =>
 			{
-				Box::new(move |utxo| utxo.ordering_key() <= (*block_number, *tx_ix, *tx_out_ix))
+				Box::new(move |utxo| utxo.ordering_key() <= (*block_number, *tx_ix))
 			},
 			_ => return None,
 		};
@@ -102,12 +102,11 @@ impl TokenUtxoCache {
 
 	pub(crate) fn try_resolve_checkpoint_from_cache(
 		&self,
-		utxo_id: &UtxoId,
+		tx_id: &McTxHash,
 	) -> Option<ResolvedBridgeDataCheckpoint> {
-		let BridgeUtxo { block_number, tx_ix, utxo_ix, .. } =
-			self.utxo_cache.get(utxo_id).cloned()?;
+		let BridgeTx { block_number, tx_ix, .. } = self.tx_cache.get(tx_id).cloned()?;
 
-		Some(ResolvedBridgeDataCheckpoint::Utxo { block_number, tx_ix, tx_out_ix: utxo_ix })
+		Some(ResolvedBridgeDataCheckpoint::Tx { block_number, tx_ix })
 	}
 }
 
@@ -133,7 +132,7 @@ observed_async_trait!(
 
 			let data_checkpoint = self.resolve_data_checkpoint(&data_checkpoint).await?;
 
-			let utxos =
+			let txs =
 				match self.try_serve_from_cache(&data_checkpoint, to_block, max_transfers).await {
 					Some(utxos) => utxos,
 					None => {
@@ -144,14 +143,14 @@ observed_async_trait!(
 					},
 				};
 
-			let new_checkpoint = match utxos.last() {
-				Some(utxo) if (utxos.len() as u32) >= max_transfers => {
-					BridgeDataCheckpoint::Utxo(utxo.utxo_id())
+			let new_checkpoint = match txs.last() {
+				Some(tx) if (txs.len() as u32) >= max_transfers => {
+					BridgeDataCheckpoint::Tx(tx.tx_id())
 				},
 				_ => BridgeDataCheckpoint::Block(to_block.into()),
 			};
 
-			let transfers = utxos.into_iter().flat_map(utxo_to_transfer).collect();
+			let transfers = txs.into_iter().map(tx_to_transfer).collect();
 
 			Ok((transfers, new_checkpoint))
 		}
@@ -186,7 +185,7 @@ impl CachedTokenBridgeDataSourceImpl {
 		data_checkpoint: &ResolvedBridgeDataCheckpoint,
 		to_block: BlockNumber,
 		max_transfers: u32,
-	) -> Option<Vec<BridgeUtxo>> {
+	) -> Option<Vec<BridgeTx>> {
 		let cache = self.cache.lock().await;
 		cache.serve_from_cache(data_checkpoint, to_block, max_transfers)
 	}
@@ -208,7 +207,7 @@ impl CachedTokenBridgeDataSourceImpl {
 		let to_block: BlockNumber =
 			min(to_block.saturating_add(self.cache_lookahead), latest_block);
 
-		let utxos = get_bridge_utxos_tx(
+		let utxos = get_bridge_txs(
 			self.db_sync_config.get_tx_in_config().await?,
 			&self.pool,
 			&main_chain_scripts.illiquid_circulation_supply_validator_address.clone().into(),
@@ -228,10 +227,10 @@ impl CachedTokenBridgeDataSourceImpl {
 		&self,
 		start_block: BlockNumber,
 		end_block: BlockNumber,
-		utxos: Vec<BridgeUtxo>,
+		txs: Vec<BridgeTx>,
 	) {
 		let mut cache = self.cache.lock().await;
-		cache.set_cached_transfers(start_block, end_block, utxos);
+		cache.set_cached_transfers(start_block, end_block, txs);
 	}
 
 	async fn get_latest_stable_block(
@@ -245,19 +244,15 @@ impl CachedTokenBridgeDataSourceImpl {
 			.map(|block| block.number.into()))
 	}
 
-	async fn resolve_checkpoint_for_utxo(
+	async fn resolve_checkpoint_for_tx_hash(
 		&self,
-		utxo_id: &UtxoId,
+		tx_hash: &McTxHash,
 	) -> Result<ResolvedBridgeDataCheckpoint, Box<dyn Error + Send + Sync>> {
 		let TxBlockInfo { block_number, tx_ix } =
-			get_block_info_for_utxo(&self.pool, utxo_id.tx_hash.into())
+			get_block_info_for_tx_hash(&self.pool, (*tx_hash).into())
 				.await?
-				.ok_or(format!("Could not find block info for utxo: {utxo_id:?}"))?;
-		Ok(ResolvedBridgeDataCheckpoint::Utxo {
-			block_number,
-			tx_ix,
-			tx_out_ix: utxo_id.index.into(),
-		})
+				.ok_or(format!("Could not find block info for tx: {tx_hash:?}"))?;
+		Ok(ResolvedBridgeDataCheckpoint::Tx { block_number, tx_ix })
 	}
 
 	async fn resolve_data_checkpoint(
@@ -268,10 +263,10 @@ impl CachedTokenBridgeDataSourceImpl {
 			BridgeDataCheckpoint::Block(number) => {
 				Ok(ResolvedBridgeDataCheckpoint::Block { number: (*number).into() })
 			},
-			BridgeDataCheckpoint::Utxo(utxo) => {
-				match self.cache.lock().await.try_resolve_checkpoint_from_cache(&utxo) {
+			BridgeDataCheckpoint::Tx(tx_hash) => {
+				match self.cache.lock().await.try_resolve_checkpoint_from_cache(&tx_hash) {
 					Some(checkpoint) => Ok(checkpoint),
-					None => self.resolve_checkpoint_for_utxo(&utxo).await,
+					None => self.resolve_checkpoint_for_tx_hash(&tx_hash).await,
 				}
 			},
 		}

--- a/toolkit/data-sources/db-sync/src/bridge/mod.rs
+++ b/toolkit/data-sources/db-sync/src/bridge/mod.rs
@@ -45,10 +45,10 @@
 use crate::McFollowerMetrics;
 use crate::db_model::*;
 use crate::metrics::observed_async_trait;
-use partner_chains_plutus_data::bridge::{TokenTransferDatum, TokenTransferDatumV1};
 use sidechain_domain::McBlockHash;
 use sp_partner_chains_bridge::*;
 use sqlx::PgPool;
+use sqlx::types::JsonValue;
 use std::fmt::Debug;
 
 #[cfg(test)]
@@ -99,25 +99,21 @@ observed_async_trait!(
 				.ok_or(format!("Could not find block for hash {current_mc_block_hash:?}"))?;
 
 			let data_checkpoint = match data_checkpoint {
-				BridgeDataCheckpoint::Utxo(utxo) => {
+				BridgeDataCheckpoint::Tx(tx_hash) => {
 					let TxBlockInfo { block_number, tx_ix } =
-						get_block_info_for_utxo(&self.pool, utxo.tx_hash.into()).await?.ok_or(
+						get_block_info_for_tx_hash(&self.pool, tx_hash.into()).await?.ok_or(
 							format!(
 								"Could not find block info for data checkpoint: {data_checkpoint:?}"
 							),
 						)?;
-					ResolvedBridgeDataCheckpoint::Utxo {
-						block_number,
-						tx_ix,
-						tx_out_ix: utxo.index.into(),
-					}
+					ResolvedBridgeDataCheckpoint::Tx { block_number, tx_ix }
 				},
 				BridgeDataCheckpoint::Block(number) => {
 					ResolvedBridgeDataCheckpoint::Block { number: number.into() }
 				},
 			};
 
-			let utxos = get_bridge_utxos_tx(
+			let txs = get_bridge_txs(
 				self.db_sync_config.get_tx_in_config().await?,
 				&self.pool,
 				&main_chain_scripts.illiquid_circulation_supply_validator_address.into(),
@@ -128,53 +124,42 @@ observed_async_trait!(
 			)
 			.await?;
 
-			let new_checkpoint = match utxos.last() {
+			let new_checkpoint = match txs.last() {
 				None => BridgeDataCheckpoint::Block(current_mc_block.block_no.into()),
-				Some(_) if (utxos.len() as u32) < max_transfers => {
+				Some(_) if (txs.len() as u32) < max_transfers => {
 					BridgeDataCheckpoint::Block(current_mc_block.block_no.into())
 				},
-				Some(utxo) => BridgeDataCheckpoint::Utxo(utxo.utxo_id()),
+				Some(tx) => BridgeDataCheckpoint::Tx(tx.tx_id()),
 			};
 
-			let transfers = utxos.into_iter().flat_map(utxo_to_transfer).collect();
+			let transfers = txs.into_iter().map(tx_to_transfer).collect();
 
 			Ok((transfers, new_checkpoint))
 		}
 	}
 );
 
-fn utxo_to_transfer<RecipientAddress>(
-	utxo: BridgeUtxo,
-) -> Option<BridgeTransferV1<RecipientAddress>>
+fn tx_to_transfer<RecipientAddress>(tx: BridgeTx) -> BridgeTransferV1<RecipientAddress>
 where
 	RecipientAddress: for<'a> TryFrom<&'a [u8]>,
 {
-	let token_delta = utxo.tokens_out.checked_sub(utxo.tokens_in)?;
-
-	if token_delta.is_zero() {
-		return None;
+	let token_amount = tx.amount.0.try_into().expect("There can't be more than u64 of cNIGHT");
+	let tx_hash = tx.tx_id();
+	match tx.c2m_metadata {
+		Some(JsonValue::Array(values)) => match values.first() {
+			None => BridgeTransferV1::ReserveTransfer { token_amount },
+			Some(JsonValue::String(str)) => {
+				let str = str.trim_start_matches("0x");
+				match hex::decode(str)
+					.ok()
+					.and_then(|bytes| RecipientAddress::try_from(&bytes).ok())
+				{
+					Some(recipient) => BridgeTransferV1::UserTransfer { token_amount, recipient },
+					None => BridgeTransferV1::InvalidTransfer { token_amount, tx_hash },
+				}
+			},
+			_ => BridgeTransferV1::InvalidTransfer { token_amount, tx_hash },
+		},
+		_ => BridgeTransferV1::InvalidTransfer { token_amount, tx_hash },
 	}
-
-	let token_amount = token_delta.0 as u64;
-
-	let Some(datum) = utxo.datum.clone() else {
-		return Some(BridgeTransferV1::InvalidTransfer { token_amount, utxo_id: utxo.utxo_id() });
-	};
-
-	let transfer = match TokenTransferDatum::try_from(datum.0) {
-		Ok(TokenTransferDatum::V1(TokenTransferDatumV1::UserTransfer { receiver })) => {
-			match RecipientAddress::try_from(receiver.0.as_ref()) {
-				Ok(recipient) => BridgeTransferV1::UserTransfer { token_amount, recipient },
-				Err(_) => {
-					BridgeTransferV1::InvalidTransfer { token_amount, utxo_id: utxo.utxo_id() }
-				},
-			}
-		},
-		Ok(TokenTransferDatum::V1(TokenTransferDatumV1::ReserveTransfer)) => {
-			BridgeTransferV1::ReserveTransfer { token_amount }
-		},
-		Err(_) => BridgeTransferV1::InvalidTransfer { token_amount, utxo_id: utxo.utxo_id() },
-	};
-
-	Some(transfer)
 }

--- a/toolkit/data-sources/db-sync/src/db_datum.rs
+++ b/toolkit/data-sources/db-sync/src/db_datum.rs
@@ -17,10 +17,7 @@ impl sqlx::Type<Postgres> for DbDatum {
 	}
 }
 
-impl<'r> sqlx::Decode<'r, Postgres> for DbDatum
-where
-	JsonValue: Decode<'r, Postgres>,
-{
+impl<'r> sqlx::Decode<'r, Postgres> for DbDatum {
 	fn decode(value: <Postgres as Database>::ValueRef<'r>) -> Result<Self, BoxDynError> {
 		let value: JsonValue = <JsonValue as Decode<Postgres>>::decode(value)?;
 		let datum = encode_json_value_to_plutus_datum(value, DetailedSchema);

--- a/toolkit/data-sources/db-sync/src/db_model.rs
+++ b/toolkit/data-sources/db-sync/src/db_model.rs
@@ -11,6 +11,7 @@ use sidechain_domain::{
 };
 use sqlx::{
 	Decode, PgPool, Pool, Postgres, database::Database, error::BoxDynError, postgres::PgTypeInfo,
+	types::JsonValue,
 };
 use std::{cell::OnceCell, str::FromStr, sync::Arc};
 use tokio::sync::Mutex;
@@ -192,7 +193,7 @@ pub(crate) struct DatumChangeOutput {
 }
 
 #[derive(Debug, Clone, PartialEq, Copy)]
-pub(crate) struct NativeTokenAmount(pub u128);
+pub struct NativeTokenAmount(pub u128);
 impl From<NativeTokenAmount> for sidechain_domain::NativeTokenAmount {
 	fn from(value: NativeTokenAmount) -> Self {
 		Self(value.0)
@@ -200,11 +201,11 @@ impl From<NativeTokenAmount> for sidechain_domain::NativeTokenAmount {
 }
 
 impl NativeTokenAmount {
-	pub(crate) fn checked_sub(self, rhs: NativeTokenAmount) -> Option<NativeTokenAmount> {
+	pub fn checked_sub(self, rhs: NativeTokenAmount) -> Option<NativeTokenAmount> {
 		self.0.checked_sub(rhs.0).map(NativeTokenAmount)
 	}
 
-	pub(crate) fn is_zero(&self) -> bool {
+	pub fn is_zero(&self) -> bool {
 		self.0 == 0
 	}
 }
@@ -840,7 +841,7 @@ mod tests {
 			1,
 		);
 
-		let result = get_block_info_for_utxo(&pool, utxo.tx_hash.into())
+		let result = get_block_info_for_tx_hash(&pool, utxo.tx_hash.into())
 			.await
 			.expect("Should succeed")
 			.expect("Should find data");
@@ -851,33 +852,33 @@ mod tests {
 
 #[cfg(feature = "bridge")]
 #[derive(Debug, Clone, sqlx::FromRow, PartialEq)]
-pub(crate) struct BridgeUtxo {
+pub(crate) struct BridgeTx {
 	pub(crate) block_number: BlockNumber,
 	pub(crate) tx_ix: TxIndexInBlock,
 	pub(crate) tx_hash: TxHash,
-	pub(crate) utxo_ix: TxIndex,
-	pub(crate) tokens_out: NativeTokenAmount,
-	pub(crate) tokens_in: NativeTokenAmount,
-	pub(crate) datum: Option<DbDatum>,
+	pub(crate) amount: NativeTokenAmount,
+	/// Value of transaction metadata with a specific C-to-M key.
+	/// Not the full metadata JSON. Db-sync metadata uses a separate row per metadata key.
+	pub(crate) c2m_metadata: Option<JsonValue>,
 }
 #[cfg(feature = "bridge")]
-impl BridgeUtxo {
-	pub(crate) fn utxo_id(&self) -> UtxoId {
-		UtxoId { tx_hash: self.tx_hash.into(), index: self.utxo_ix.into() }
+impl BridgeTx {
+	pub(crate) fn tx_id(&self) -> McTxHash {
+		self.tx_hash.into()
 	}
 
-	pub(crate) fn ordering_key(&self) -> UtxoOrderingKey {
-		(self.block_number, self.tx_ix, self.utxo_ix)
+	pub(crate) fn ordering_key(&self) -> TxOrderingKey {
+		(self.block_number, self.tx_ix)
 	}
 }
 
 #[cfg(feature = "bridge")]
-pub(crate) type UtxoOrderingKey = (BlockNumber, TxIndexInBlock, TxIndex);
+pub(crate) type TxOrderingKey = (BlockNumber, TxIndexInBlock);
 
 #[cfg(feature = "bridge")]
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub(crate) enum ResolvedBridgeDataCheckpoint {
-	Utxo { block_number: BlockNumber, tx_ix: TxIndexInBlock, tx_out_ix: TxIndex },
+	Tx { block_number: BlockNumber, tx_ix: TxIndexInBlock },
 	Block { number: BlockNumber },
 }
 
@@ -886,7 +887,7 @@ impl ResolvedBridgeDataCheckpoint {
 	pub(crate) fn get_block_number(&self) -> BlockNumber {
 		match self {
 			ResolvedBridgeDataCheckpoint::Block { number } => *number,
-			ResolvedBridgeDataCheckpoint::Utxo { block_number, .. } => *block_number,
+			ResolvedBridgeDataCheckpoint::Tx { block_number, .. } => *block_number,
 		}
 	}
 }
@@ -899,7 +900,7 @@ pub(crate) struct TxBlockInfo {
 }
 
 #[cfg(feature = "bridge")]
-pub(crate) async fn get_block_info_for_utxo(
+pub(crate) async fn get_block_info_for_tx_hash(
 	pool: &Pool<Postgres>,
 	tx_hash: TxHash,
 ) -> Result<Option<TxBlockInfo>, SqlxError> {
@@ -920,82 +921,103 @@ WHERE tx.hash = $1
 }
 
 #[cfg(feature = "bridge")]
-pub(crate) async fn get_bridge_utxos_tx(
+pub(crate) async fn get_bridge_txs(
 	tx_in_configuration: TxInConfiguration,
 	pool: &Pool<Postgres>,
 	icp_address: &Address,
 	native_token: Asset,
 	checkpoint: ResolvedBridgeDataCheckpoint,
 	to_block: BlockNumber,
-	max_utxos: Option<u32>,
-) -> Result<Vec<BridgeUtxo>, SqlxError> {
+	max_transfers: Option<u32>,
+) -> Result<Vec<BridgeTx>, SqlxError> {
+	use partner_chains_plutus_data::bridge::TOKEN_TRANSFER_METADATUM_KEY;
 	use sqlx::QueryBuilder;
 
-	let mut query_builder = QueryBuilder::new(
-		"
-	SELECT
-	      block.block_no                          AS block_number
-	    , tx.block_index                          AS tx_ix
-	    , tx.hash                                 AS tx_hash
-	    , outputs.index                           AS utxo_ix
-	    , output_tokens.quantity                  AS tokens_out
-	    , coalesce(sum(input_tokens.quantity), 0) AS tokens_in
-	    , datum.value                             AS datum
+	let max_rows = max_transfers.as_ref().map(ToString::to_string).unwrap_or("null".into());
 
-	FROM tx_out      outputs
-	JOIN tx                        ON outputs.tx_id = tx.id
-	JOIN block                     ON tx.block_id = block.id
-	JOIN ma_tx_out   output_tokens ON output_tokens.tx_out_id = outputs.id
-	JOIN multi_asset native_token  ON native_token.id = output_tokens.ident
-	LEFT JOIN datum                     ON datum.hash = outputs.data_hash
-",
-	);
-
-	query_builder.push(match tx_in_configuration {
-		TxInConfiguration::Consumed =>
-				"LEFT JOIN tx_out     inputs        ON inputs.consumed_by_tx_id = tx.id   AND inputs.address = $1",
-		TxInConfiguration::Enabled =>
-				"LEFT JOIN tx_in      inputs_join   ON tx.id = inputs_join.tx_in_id
-                 LEFT JOIN tx_out     inputs        ON inputs_join.tx_out_id = inputs.tx_id and inputs_join.tx_out_index = inputs.index AND inputs.address = $1",
-	});
-
-	query_builder.push(
-		"
-	LEFT JOIN ma_tx_out  input_tokens  ON input_tokens.tx_out_id = inputs.id AND input_tokens.ident = native_token.id
-	WHERE native_token.policy = $2
-	  AND native_token.name = $3
-	  AND outputs.address = $1
-	  AND block_no <= $4
-",
-	);
-
-	match checkpoint {
+	let checkpoint_limit = match checkpoint {
 		ResolvedBridgeDataCheckpoint::Block { number } => {
-			query_builder.push(&format!("AND block_no > {} ", number.0));
+			format!("block.block_no > {}", number.0)
 		},
-		ResolvedBridgeDataCheckpoint::Utxo { block_number, tx_ix, tx_out_ix } => {
-			query_builder.push(&format!(
-				"AND (block_no, tx.block_index, outputs.index) > ({}, {}, {}) ",
-				block_number.0, tx_ix.0, tx_out_ix.0
-			));
+		ResolvedBridgeDataCheckpoint::Tx { block_number, tx_ix } => {
+			format!("(block.block_no, tx.block_index) > ({}, {})", block_number.0, tx_ix.0)
 		},
-	}
+	};
+	// TODO: improve query by using metadata.ident "cache" and tx, tx_out, ma_tx_out, tx_metadata and tx_in ids boundries. https://github.com/midnightntwrk/partner-chains/issues/26
+	let transfers_subquery = format!(
+		"
+		SELECT
+			  block.block_no                            AS block_number
+			, tx.block_index                            AS tx_ix
+			, tx.hash                                   AS tx_hash
+			, tx.id                                     AS tx_id
+			, tx_metadata.json						    AS c2m_metadata
+			, coalesce(sum(output_tokens.quantity), 0)  AS tokens_out
+			, native_token.id                           AS native_token_id
+		FROM tx_out         outputs
+		JOIN tx                               ON outputs.tx_id = tx.id
+		JOIN block                            ON tx.block_id = block.id
+		JOIN ma_tx_out      output_tokens     ON output_tokens.tx_out_id = outputs.id
+		JOIN multi_asset    native_token      ON native_token.id = output_tokens.ident
+		LEFT JOIN           tx_metadata       ON tx_metadata.tx_id = tx.id AND tx_metadata.key = $5
+		WHERE native_token.policy = $2
+          AND native_token.name = $3
+          AND outputs.address = $1
+          AND block_no <= $4
+          AND {checkpoint_limit}
+		GROUP BY tx.id, tx.hash, tx_metadata.json, block.block_no, tx.block_index, native_token.id
+		LIMIT {max_rows}
+"
+	);
 
-	query_builder
-		.push("GROUP BY tx.hash, outputs.id, output_tokens.quantity, datum.value, block.block_no, tx.block_index, outputs.index ")
-		.push("ORDER BY block.block_no, tx.block_index, outputs.index ");
+	let inputs_subquery = match tx_in_configuration {
+		TxInConfiguration::Consumed => {
+			"
+			SELECT
+				  tx_out.consumed_by_tx_id  AS consuming_tx_id
+                , ma_tx_out.ident           AS native_token_id
+                , ma_tx_out.quantity        AS tokens_in
+			FROM tx_out
+			LEFT JOIN ma_tx_out ON ma_tx_out.tx_out_id = tx_out.id
+			WHERE tx_out.address = $1
+		"
+		},
+		TxInConfiguration::Enabled => {
+			"
+			SELECT
+                  tx_in.tx_in_id         AS consuming_tx_id
+                , ma_tx_out.ident        AS native_token_id
+                , ma_tx_out.quantity     AS tokens_in
+			FROM tx_out
+			LEFT JOIN ma_tx_out ON ma_tx_out.tx_out_id = tx_out.id
+			LEFT JOIN tx_in     ON tx_in.tx_out_id = tx_out.tx_id and tx_in.tx_out_index = tx_out.index
+			WHERE tx_out.address = $1
+		"
+		},
+	};
 
-	if let Some(max_utxos) = max_utxos {
-		query_builder.push(&format!("LIMIT {max_utxos}"));
-	}
-	query_builder.push(";");
+	let mut query_builder = QueryBuilder::new(&format!("
+		WITH
+            transfers AS ({transfers_subquery})
+		  , inputs    AS ({inputs_subquery})
+		SELECT
+            block_number
+          , tx_ix
+          , tx_hash
+          , tokens_out - coalesce(sum(tokens_in), 0) as amount
+          , c2m_metadata
+		FROM transfers
+		LEFT JOIN inputs ON inputs.consuming_tx_id = transfers.tx_id AND inputs.native_token_id = transfers.native_token_id
+		GROUP BY tx_hash, c2m_metadata, block_number, tx_ix, tokens_out
+		ORDER BY block_number, tx_ix;
+	"));
 
 	let query = query_builder
-		.build_query_as::<BridgeUtxo>()
+		.build_query_as::<BridgeTx>()
 		.bind(&icp_address.0)
 		.bind(&native_token.policy_id.0)
 		.bind(&native_token.asset_name.0)
-		.bind(to_block);
-
+		.bind(to_block)
+		.bind(i64::try_from(TOKEN_TRANSFER_METADATUM_KEY).expect("Constant is valid i64"));
 	Ok(query.fetch_all(pool).await?)
 }

--- a/toolkit/data-sources/db-sync/testdata/bridge/migrations-tx-in-consumed/1_create_schema.sql
+++ b/toolkit/data-sources/db-sync/testdata/bridge/migrations-tx-in-consumed/1_create_schema.sql
@@ -204,3 +204,13 @@ CREATE TABLE public.ma_tx_out (
 	-- CONSTRAINT ma_tx_out_tx_out_id_fkey FOREIGN KEY (tx_out_id) REFERENCES public.tx_out(id) ON DELETE CASCADE ON UPDATE RESTRICT
 );
 CREATE INDEX idx_ma_tx_out_tx_out_id ON public.ma_tx_out USING btree (tx_out_id);
+
+CREATE TABLE tx_metadata (
+	id SERIAL8  PRIMARY KEY UNIQUE,
+	"key" word64type NOT NULL,
+	json jsonb NULL,
+	bytes bytea NOT NULL,
+	tx_id INT8 NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_tx_metadata_tx_id ON tx_metadata(tx_id) ;

--- a/toolkit/data-sources/db-sync/testdata/bridge/migrations-tx-in-consumed/6_insert_transactions.sql
+++ b/toolkit/data-sources/db-sync/testdata/bridge/migrations-tx-in-consumed/6_insert_transactions.sql
@@ -1,33 +1,11 @@
 DO $$
 DECLARE
-  reserve_datum jsonb := '{
-					"list": [
-						{ "constructor": 0, "fields": [] },
-						{ "constructor": 1, "fields": [] },
-						{ "int": 1 }
-					]
-		}';
 
-  transfer_datum_1 jsonb := '{
-					"list": [
-						{ "constructor": 0, "fields": [] },
-						{ "constructor": 0, "fields": [{ "bytes": "abcd" }] },
-						{ "int": 1 }
-					]
-		}';
-
-  transfer_datum_2 jsonb := '{
-					"list": [
-						{ "constructor": 0, "fields": [] },
-						{ "constructor": 0, "fields": [{ "bytes": "1234" }] },
-						{ "int": 1 }
-					]
-		}';
-
- invalid_datum jsonb := '{
-        "list": [ { "int": 42 } ]
-    }';
-
+ unit_datum jsonb := '{ "constructor": 0, "fields": [] }';
+ reserve_metadatum jsonb := '[]';
+ transfer_metadatum_1 jsonb := '["0xabcd"]';
+ transfer_metadatum_2 jsonb := '["0x1234"]';
+ invalid_metadatum jsonb := '{ "it is no a string": "but a map" }';
 
  native_token_policy hash28type := decode('500000000000000000000000000000000000434845434b504f494e69', 'hex');
  native_token_id integer := 1;
@@ -50,10 +28,7 @@ DECLARE
  ivalid_transfer_tx_hash_2 hash32type := decode('c000000000000000000000000000000000000000000000000000000000000006','hex');
  irrelevant_tx_hash hash32type := decode('4242424242424242424242424242424242424242424242424242424242424242','hex');
 
- reserve_transfer_datum_hash hash32type := decode('0000000000000000000000000000000000000000000000000000000000000001','hex');
- user_tranfer_datum_hash_1 hash32type := decode('1000000000000000000000000000000000000000000000000000000000000001','hex');
- user_tranfer_datum_hash_2 hash32type := decode('1000000000000000000000000000000000000000000000000000000000000002','hex');
- invalid_transfer_datum hash32type := decode('1000000000000000000000000000000000000000000000000000000000000003','hex');
+ unit_datum_hash hash32type := decode('0000000000000000000000000000000000000000000000000000000000000001','hex');
 
 BEGIN
 
@@ -74,18 +49,25 @@ INSERT INTO tx_out ( id, tx_id                 , index, address     , address_ra
                   ,( 13, init_ics_tx           , 2    , 'ics address', ''         , TRUE              , NULL        , NULL            , 0    , NULL                        , NULL                  ) -- ICS initial utxo 3
                   ,( 14, init_ics_tx           , 3    , 'ics address', ''         , TRUE              , NULL        , NULL            , 0    , NULL                        , NULL                  ) -- ICS initial utxo 4
                   ,( 15, irrelevant_tx         , 0    , 'irrelevant' , ''         , TRUE              , NULL        , NULL            , 0    , NULL                        , user_transfer_tx_2    ) -- Irrelevant transaction with some native token
-                  ,( 21, reserve_transfer_tx   , 0    , 'ics address', ''         , TRUE              , NULL        , NULL            , 0    , reserve_transfer_datum_hash , user_transfer_tx_1    ) -- transfers 100 tokens
-                  ,( 31, user_transfer_tx_1    , 0    , 'ics address', ''         , TRUE              , NULL        , NULL            , 0    , user_tranfer_datum_hash_1   , user_transfer_tx_2    ) -- transfers 10 tokens + 100 tokens from previous transaction's utxo, consumes `irrelevant_tx#0`
-                  ,( 32, user_transfer_tx_2    , 1    , 'ics address', ''         , TRUE              , NULL        , NULL            , 0    , user_tranfer_datum_hash_2   , invalid_transfer_tx_1 ) -- transfers 10 tokens + 110 tokens from previous transaction's utxo
-                  ,( 41, invalid_transfer_tx_1 , 0    , 'ics address', ''         , TRUE              , NULL        , NULL            , 0    , invalid_transfer_datum      , NULL                  ) -- invalid transfer, with invalid datum
-                  ,( 42, invalid_transfer_tx_2 , 0    , 'ics address', ''         , TRUE              , NULL        , NULL            , 0    , NULL                        , NULL                  ) -- invalid transfer, no datum
+                  ,( 21, reserve_transfer_tx   , 0    , 'ics address', ''         , TRUE              , NULL        , NULL            , 0    , unit_datum_hash             , user_transfer_tx_1    ) -- transfers 100 tokens
+                  ,( 31, user_transfer_tx_1    , 0    , 'ics address', ''         , TRUE              , NULL        , NULL            , 0    , unit_datum_hash             , user_transfer_tx_2    ) -- transfers 10 tokens + 100 tokens from previous transaction's utxo, consumes `irrelevant_tx#0`
+                  ,( 32, user_transfer_tx_2    , 1    , 'ics address', ''         , TRUE              , NULL        , NULL            , 0    , unit_datum_hash             , invalid_transfer_tx_1 ) -- transfers 10 tokens + 110 tokens from previous transaction's utxo
+                  ,( 41, invalid_transfer_tx_1 , 0    , 'ics address', ''         , TRUE              , NULL        , NULL            , 0    , unit_datum_hash             , NULL                  ) -- transfer with invalid metadatum
+                  ,( 42, invalid_transfer_tx_2 , 0    , 'ics address', ''         , TRUE              , NULL        , NULL            , 0    , NULL                        , NULL                  ) -- invalid transfer, no metadatum
 ;
 
-INSERT INTO datum ( id, hash                        , tx_id                  , value            )
-           VALUES ( 0 , reserve_transfer_datum_hash , irrelevant_tx          , reserve_datum    )
-                 ,( 1 , user_tranfer_datum_hash_1   , irrelevant_tx          , transfer_datum_1 )
-                 ,( 2 , user_tranfer_datum_hash_2   , irrelevant_tx          , transfer_datum_2 )
-                 ,( 3 , invalid_transfer_datum      , irrelevant_tx          , invalid_datum    )
+INSERT INTO datum ( id, hash                       , tx_id        , value         )
+           VALUES ( 0 , unit_datum_hash , reserve_transfer_tx     , unit_datum    )
+                , ( 1 , unit_datum_hash , user_transfer_tx_1      , unit_datum    )
+                , ( 2 , unit_datum_hash , user_transfer_tx_2      , unit_datum    )
+                , ( 3 , unit_datum_hash , invalid_transfer_tx_1   , unit_datum    )
+;
+
+INSERT INTO tx_metadata ( id , "key"   , json                 , bytes , tx_id                 )
+	             VALUES ( 0  , 6500973 , reserve_metadatum    , ''    , reserve_transfer_tx   )
+	                  , ( 1  , 6500973 , transfer_metadatum_1 , ''    , user_transfer_tx_1    )
+	                  , ( 2  , 6500973 , transfer_metadatum_2 , ''    , user_transfer_tx_2    )
+	                  , ( 3  , 6500973 , invalid_metadatum    , ''    , invalid_transfer_tx_1 )
 ;
 
 INSERT INTO multi_asset ( id                  , policy                  , name               , fingerprint       )
@@ -109,4 +91,3 @@ VALUES                (11 , 100      , 21        , native_token_id )
 ;
 
 END $$;
-

--- a/toolkit/data-sources/db-sync/testdata/bridge/migrations-tx-in-enabled/1_create_schema.sql
+++ b/toolkit/data-sources/db-sync/testdata/bridge/migrations-tx-in-enabled/1_create_schema.sql
@@ -211,3 +211,13 @@ CREATE TABLE public.ma_tx_out (
 	-- CONSTRAINT ma_tx_out_tx_out_id_fkey FOREIGN KEY (tx_out_id) REFERENCES public.tx_out(id) ON DELETE CASCADE ON UPDATE RESTRICT
 );
 CREATE INDEX idx_ma_tx_out_tx_out_id ON public.ma_tx_out USING btree (tx_out_id);
+
+CREATE TABLE tx_metadata (
+	id SERIAL8  PRIMARY KEY UNIQUE,
+	"key" word64type NOT NULL,
+	json jsonb NULL,
+	bytes bytea NOT NULL,
+	tx_id INT8 NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_tx_metadata_tx_id ON tx_metadata(tx_id) ;

--- a/toolkit/data-sources/db-sync/testdata/bridge/migrations-tx-in-enabled/6_insert_transactions.sql
+++ b/toolkit/data-sources/db-sync/testdata/bridge/migrations-tx-in-enabled/6_insert_transactions.sql
@@ -1,33 +1,10 @@
 DO $$
 DECLARE
-  reserve_datum jsonb := '{
-					"list": [
-						{ "constructor": 0, "fields": [] },
-						{ "constructor": 1, "fields": [] },
-						{ "int": 1 }
-					]
-		}';
-
-  transfer_datum_1 jsonb := '{
-					"list": [
-						{ "constructor": 0, "fields": [] },
-						{ "constructor": 0, "fields": [{ "bytes": "abcd" }] },
-						{ "int": 1 }
-					]
-		}';
-
-  transfer_datum_2 jsonb := '{
-					"list": [
-						{ "constructor": 0, "fields": [] },
-						{ "constructor": 0, "fields": [{ "bytes": "1234" }] },
-						{ "int": 1 }
-					]
-		}';
-
- invalid_datum jsonb := '{
-        "list": [ { "int": 42 } ]
-    }';
-
+ unit_datum jsonb := '{ "constructor": 0, "fields": [] }';
+ reserve_metadatum jsonb := '[]';
+ transfer_metadatum_1 jsonb := '["0xabcd"]';
+ transfer_metadatum_2 jsonb := '["0x1234"]';
+ invalid_metadatum jsonb := '{ "it is no a string": "but a map" }';
 
  native_token_policy hash28type := decode('500000000000000000000000000000000000434845434b504f494e69', 'hex');
  native_token_id integer := 1;
@@ -50,10 +27,7 @@ DECLARE
  ivalid_transfer_tx_hash_2 hash32type := decode('c000000000000000000000000000000000000000000000000000000000000006','hex');
  irrelevant_tx_hash hash32type := decode('4242424242424242424242424242424242424242424242424242424242424242','hex');
 
- reserve_transfer_datum_hash hash32type := decode('0000000000000000000000000000000000000000000000000000000000000001','hex');
- user_tranfer_datum_hash_1 hash32type := decode('1000000000000000000000000000000000000000000000000000000000000001','hex');
- user_tranfer_datum_hash_2 hash32type := decode('1000000000000000000000000000000000000000000000000000000000000002','hex');
- invalid_transfer_datum hash32type := decode('1000000000000000000000000000000000000000000000000000000000000003','hex');
+ unit_datum_hash hash32type := decode('0000000000000000000000000000000000000000000000000000000000000001','hex');
 
 BEGIN
 
@@ -68,24 +42,31 @@ INSERT INTO tx ( id                    , hash                       , block_id, 
 ;
 
 
-INSERT INTO tx_out ( id, tx_id                 , index, address     , address_raw, address_has_script, payment_cred, stake_address_id, value, data_hash                    )
-            VALUES ( 11, init_ics_tx           , 0    , 'ics address', ''         , TRUE              , NULL        , NULL            , 0    , NULL                        ) -- ICS initial utxo 1
-                  ,( 12, init_ics_tx           , 1    , 'ics address', ''         , TRUE              , NULL        , NULL            , 0    , NULL                        ) -- ICS initial utxo 2
-                  ,( 13, init_ics_tx           , 2    , 'ics address', ''         , TRUE              , NULL        , NULL            , 0    , NULL                        ) -- ICS initial utxo 3
-                  ,( 14, init_ics_tx           , 3    , 'ics address', ''         , TRUE              , NULL        , NULL            , 0    , NULL                        ) -- ICS initial utxo 4
-                  ,( 15, irrelevant_tx         , 0    , 'irrelevant' , ''         , TRUE              , NULL        , NULL            , 0    , NULL                        ) -- Irrelevant transaction with some native token
-                  ,( 21, reserve_transfer_tx   , 0    , 'ics address', ''         , TRUE              , NULL        , NULL            , 0    , reserve_transfer_datum_hash ) -- transfers 100 tokens
-                  ,( 31, user_transfer_tx_1    , 0    , 'ics address', ''         , TRUE              , NULL        , NULL            , 0    , user_tranfer_datum_hash_1   ) -- transfers 10 tokens + 100 tokens from previous transaction's utxo
-                  ,( 32, user_transfer_tx_2    , 0    , 'ics address', ''         , TRUE              , NULL        , NULL            , 0    , user_tranfer_datum_hash_2   ) -- transfers 10 tokens + 110 tokens from previous transaction's utxo
-                  ,( 41, invalid_transfer_tx_1 , 0    , 'ics address', ''         , TRUE              , NULL        , NULL            , 0    , invalid_transfer_datum      ) -- invalid transfer, invalid datum
-                  ,( 42, invalid_transfer_tx_2 , 0    , 'ics address', ''         , TRUE              , NULL        , NULL            , 0    , NULL                        ) -- invalid transfer, no datum
+INSERT INTO tx_out ( id, tx_id                 , index, address     , address_raw, address_has_script, payment_cred, stake_address_id, value, data_hash )
+            VALUES ( 11, init_ics_tx           , 0    , 'ics address', ''         , TRUE              , NULL        , NULL            , 0    , NULL     ) -- ICS initial utxo 1
+                  ,( 12, init_ics_tx           , 1    , 'ics address', ''         , TRUE              , NULL        , NULL            , 0    , NULL     ) -- ICS initial utxo 2
+                  ,( 13, init_ics_tx           , 2    , 'ics address', ''         , TRUE              , NULL        , NULL            , 0    , NULL     ) -- ICS initial utxo 3
+                  ,( 14, init_ics_tx           , 3    , 'ics address', ''         , TRUE              , NULL        , NULL            , 0    , NULL     ) -- ICS initial utxo 4
+                  ,( 15, irrelevant_tx         , 0    , 'irrelevant' , ''         , TRUE              , NULL        , NULL            , 0    , NULL     ) -- Irrelevant transaction with some native token
+                  ,( 21, reserve_transfer_tx   , 0    , 'ics address', ''         , TRUE              , NULL        , NULL            , 0    , NULL     ) -- transfers 100 tokens
+                  ,( 31, user_transfer_tx_1    , 0    , 'ics address', ''         , TRUE              , NULL        , NULL            , 0    , NULL     ) -- transfers 10 tokens + 100 tokens from previous transaction's utxo
+                  ,( 32, user_transfer_tx_2    , 0    , 'ics address', ''         , TRUE              , NULL        , NULL            , 0    , NULL     ) -- transfers 10 tokens + 110 tokens from previous transaction's utxo
+                  ,( 41, invalid_transfer_tx_1 , 0    , 'ics address', ''         , TRUE              , NULL        , NULL            , 0    , NULL     ) -- invalid transfer, invalid datum
+                  ,( 42, invalid_transfer_tx_2 , 0    , 'ics address', ''         , TRUE              , NULL        , NULL            , 0    , NULL     ) -- invalid transfer, no datum
 ;
 
-INSERT INTO datum ( id, hash                        , tx_id                  , value            )
-           VALUES ( 0 , reserve_transfer_datum_hash , irrelevant_tx          , reserve_datum    )
-                 ,( 1 , user_tranfer_datum_hash_1   , irrelevant_tx          , transfer_datum_1 )
-                 ,( 2 , user_tranfer_datum_hash_2   , irrelevant_tx          , transfer_datum_2 )
-                 ,( 3 , invalid_transfer_datum      , irrelevant_tx          , invalid_datum    )
+INSERT INTO datum ( id, hash            , tx_id         , value      )
+           VALUES ( 0 , unit_datum_hash , irrelevant_tx , unit_datum )
+                , ( 1 , unit_datum_hash , irrelevant_tx , unit_datum )
+                , ( 2 , unit_datum_hash , irrelevant_tx , unit_datum )
+                , ( 3 , unit_datum_hash , irrelevant_tx , unit_datum )
+;
+
+INSERT INTO tx_metadata ( id , "key"   , json                 , bytes , tx_id                 )
+	             VALUES ( 0  , 6500973 , reserve_metadatum    , ''    , reserve_transfer_tx   )
+	                  , ( 1  , 6500973 , transfer_metadatum_1 , ''    , user_transfer_tx_1    )
+	                  , ( 2  , 6500973 , transfer_metadatum_2 , ''    , user_transfer_tx_2    )
+	                  , ( 3  , 6500973 , invalid_metadatum    , ''    , invalid_transfer_tx_1 )
 ;
 
 INSERT INTO multi_asset ( id                  , policy              , name               , fingerprint       )

--- a/toolkit/partner-chains-cli/src/create_chain_spec/mod.rs
+++ b/toolkit/partner-chains-cli/src/create_chain_spec/mod.rs
@@ -221,7 +221,7 @@ impl<Keys: MaybeFromCandidateKeys> CreateChainSpecConfig<Keys> {
 					.illiquid_circulation_supply_validator_address
 					.clone(),
 			}),
-			initial_checkpoint: Some(self.genesis_utxo),
+			initial_checkpoint: Some(self.genesis_utxo.tx_hash),
 			_marker: PhantomData,
 		}
 	}

--- a/toolkit/partner-chains-cli/src/create_chain_spec/tests.rs
+++ b/toolkit/partner-chains-cli/src/create_chain_spec/tests.rs
@@ -256,7 +256,7 @@ fn generated_chain_spec() -> serde_json::Value {
 				"marker": null,
 			},
 			"bridge": {
-				"initialCheckpoint": "0000000000000000000000000000000000000000000000000000000000000000#0",
+				"initialCheckpoint": "0x0000000000000000000000000000000000000000000000000000000000000000",
 				"mainChainScripts": {
 					"illiquid_circulation_supply_validator_address": "addr_test1wrhvtvx3f0g9wv9rx8kfqc60jva3e07nqujk2cspekv4mqs9rjdvz",
 					"token_asset_name": "0x5043546f6b656e44656d6f",

--- a/toolkit/sidechain/domain/src/lib.rs
+++ b/toolkit/sidechain/domain/src/lib.rs
@@ -924,6 +924,13 @@ impl TryFrom<Vec<u8>> for McTxHash {
 	}
 }
 
+impl Display for McTxHash {
+	fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+		let hash = sp_core::hexdisplay::HexDisplay::from(&self.0);
+		write!(f, "{}", hash)
+	}
+}
+
 #[derive(
 	Default,
 	Clone,

--- a/toolkit/smart-contracts/offchain/src/bridge/deposit.rs
+++ b/toolkit/smart-contracts/offchain/src/bridge/deposit.rs
@@ -12,12 +12,12 @@ use crate::{
 	cardano_keys::CardanoPaymentSigningKey,
 	csl::{
 		CostStore, Costs, MultiAssetExt, OgmiosUtxoExt, TransactionBuilderExt, TransactionContext,
-		TransactionOutputAmountBuilderExt, get_builder_config,
+		TransactionOutputAmountBuilderExt, get_builder_config, unit_plutus_data,
 	},
 };
 use cardano_serialization_lib::{
-	Address, AssetName, BigNum, MultiAsset, PlutusData, ScriptHash, Transaction,
-	TransactionBuilder, TransactionOutputBuilder, TxInputsBuilder,
+	Address, AssetName, BigNum, MultiAsset, ScriptHash, Transaction, TransactionBuilder,
+	TransactionOutputBuilder, TxInputsBuilder,
 };
 use ogmios_client::{
 	query_ledger_state::{QueryLedgerState, QueryUtxoByUtxoId},
@@ -25,8 +25,10 @@ use ogmios_client::{
 	transactions::Transactions,
 	types::OgmiosUtxo,
 };
-use partner_chains_plutus_data::bridge::TokenTransferDatumV1;
-use sidechain_domain::{AssetId, McTxHash, UtxoId, byte_string::ByteString};
+use partner_chains_plutus_data::bridge::{
+	TOKEN_TRANSFER_METADATUM_KEY, transfer_to_addressed_transaction_metadatum,
+};
+use sidechain_domain::{AssetId, McTxHash, UtxoId};
 use std::num::NonZero;
 
 use super::{ICSData, add_ics_utxo_input_with_validator_script_reference};
@@ -99,9 +101,13 @@ fn deposit_only_tx(
 	ctx: &TransactionContext,
 ) -> anyhow::Result<Transaction> {
 	let mut tx_builder = TransactionBuilder::new(&get_builder_config(ctx)?);
+	tx_builder.add_metadatum(
+		&TOKEN_TRANSFER_METADATUM_KEY.into(),
+		&transfer_to_addressed_transaction_metadatum(pc_address)?,
+	);
 	let output_builder = TransactionOutputBuilder::new()
 		.with_address(ics_address)
-		.with_plutus_data(&to_user_transfer_datum(pc_address))
+		.with_plutus_data(&unit_plutus_data()) // Do not remove, it is critical to have any datum for validator logic
 		.next()?;
 	let ma = MultiAsset::new().with_asset_amount(&token_amount.token, token_amount.amount)?;
 	let output = output_builder.with_minimum_ada_and_asset(&ma, ctx)?.build()?;
@@ -196,9 +202,13 @@ fn deposit_tx(
 	costs: Costs,
 ) -> anyhow::Result<Transaction> {
 	let mut tx_builder = TransactionBuilder::new(&get_builder_config(ctx)?);
+	tx_builder.add_metadatum(
+		&TOKEN_TRANSFER_METADATUM_KEY.into(),
+		&transfer_to_addressed_transaction_metadatum(pc_address)?,
+	);
 	let output_builder = TransactionOutputBuilder::new()
 		.with_address(ics_address)
-		.with_plutus_data(&to_user_transfer_datum(pc_address))
+		.with_plutus_data(&unit_plutus_data()) // Unit plutus data is mandatory for  smart contracts
 		.next()?;
 	let mut ma = ics_utxo
 		.to_csl()?
@@ -235,8 +245,4 @@ fn deposit_tx(
 	);
 
 	Ok(tx_builder.balance_update_and_build(ctx)?)
-}
-
-fn to_user_transfer_datum(pc_address: &[u8]) -> PlutusData {
-	TokenTransferDatumV1::UserTransfer { receiver: ByteString(pc_address.to_vec()) }.into()
 }

--- a/toolkit/smart-contracts/offchain/src/reserve/handover.rs
+++ b/toolkit/smart-contracts/offchain/src/reserve/handover.rs
@@ -27,6 +27,7 @@ use crate::{
 	csl::{
 		AssetIdExt, CostStore, Costs, OgmiosUtxoExt, Script, TransactionBuilderExt,
 		TransactionContext, TransactionExt, TransactionOutputAmountBuilderExt, get_builder_config,
+		unit_plutus_data,
 	},
 	governance::GovernanceData,
 	multisig::{MultiSigSmartContractResult, submit_or_create_tx_to_sign},
@@ -40,7 +41,10 @@ use ogmios_client::{
 	transactions::Transactions,
 	types::OgmiosUtxo,
 };
-use partner_chains_plutus_data::{bridge::TokenTransferDatumV1, reserve::ReserveRedeemer};
+use partner_chains_plutus_data::{
+	bridge::{TOKEN_TRANSFER_METADATUM_KEY, transfer_to_reserve_metadatum},
+	reserve::ReserveRedeemer,
+};
 use sidechain_domain::UtxoId;
 
 /// Spends current UTXO at validator address to illiquid supply validator and burn reserve auth policy token, preventing further operations.
@@ -92,6 +96,9 @@ fn build_tx(
 
 	let reserve_auth_policy_spend_cost = costs.get_one_spend();
 
+	tx_builder
+		.add_metadatum(&TOKEN_TRANSFER_METADATUM_KEY.into(), &transfer_to_reserve_metadatum());
+
 	// mint goveranance token
 	tx_builder.add_mint_one_script_token_using_reference_script(
 		&governance.policy.script(),
@@ -138,9 +145,7 @@ fn illiquid_supply_validator_output(
 		TransactionOutputBuilder::new().with_address(&scripts.validator.address(ctx.network));
 	if output_value.amount > 0 {
 		let ma = output_value.token.to_multi_asset(output_value.amount)?;
-		let amount_builder = tx_output_builder
-			.with_plutus_data(&TokenTransferDatumV1::ReserveTransfer.into())
-			.next()?;
+		let amount_builder = tx_output_builder.with_plutus_data(&unit_plutus_data()).next()?;
 		amount_builder.with_minimum_ada_and_asset(&ma, ctx)?.build()
 	} else {
 		// Smart-contract requires to deposit exactly one UTXO in the illiquid supply validator,

--- a/toolkit/smart-contracts/offchain/src/reserve/release.rs
+++ b/toolkit/smart-contracts/offchain/src/reserve/release.rs
@@ -39,7 +39,10 @@ use ogmios_client::{
 	query_ledger_state::*, query_network::QueryNetwork, transactions::Transactions,
 	types::OgmiosUtxo,
 };
-use partner_chains_plutus_data::{bridge::TokenTransferDatumV1, reserve::ReserveRedeemer};
+use partner_chains_plutus_data::{
+	bridge::{TOKEN_TRANSFER_METADATUM_KEY, transfer_to_reserve_metadatum},
+	reserve::ReserveRedeemer,
+};
 use sidechain_domain::{McTxHash, UtxoId};
 use std::num::NonZero;
 
@@ -130,6 +133,9 @@ fn reserve_release_tx(
 	let left_in_reserve = reserve_balance.checked_sub(amount_to_transfer)
 		.ok_or_else(||anyhow!("Not enough funds in the reserve to transfer {amount_to_transfer} tokens (reserve balance: {reserve_balance})"))?;
 
+	tx_builder
+		.add_metadatum(&TOKEN_TRANSFER_METADATUM_KEY.into(), &transfer_to_reserve_metadatum());
+
 	// Additional reference scripts
 	tx_builder.add_script_reference_input(
 		&reserve_data.auth_policy_version_utxo.to_csl_tx_input(),
@@ -202,7 +208,7 @@ fn reserve_release_tx(
 	tx_builder.add_output(&{
 		TransactionOutputBuilder::new()
 			.with_address(&ics_data.scripts.validator.address(ctx.network))
-			.with_plutus_data(&TokenTransferDatumV1::ReserveTransfer.into())
+			.with_plutus_data(&unit_plutus_data())
 			.next()?
 			.with_minimum_ada_and_asset(&ics_tokens, ctx)?
 			.build()?

--- a/toolkit/smart-contracts/plutus-data/src/bridge.rs
+++ b/toolkit/smart-contracts/plutus-data/src/bridge.rs
@@ -1,170 +1,20 @@
-//! Plutus data types used by the token bridge
+//! Constants and types used by the token bridge
 
-use crate::*;
-use cardano_serialization_lib::{PlutusData, traits::NoneOrEmpty};
-use sidechain_domain::byte_string::ByteString;
+use cardano_serialization_lib::{JsError, MetadataList, TransactionMetadatum};
 
-/// Datum containing token transfer data
-#[derive(Clone, Debug, PartialEq)]
-pub enum TokenTransferDatum {
-	/// Version 1
-	V1(TokenTransferDatumV1),
+/// Arbitrary key, used as top-level metadatum key 6500973 = 0x63326d ~= 'c2n'
+pub const TOKEN_TRANSFER_METADATUM_KEY: u64 = 6500973;
+
+/// Metadata item for transfer to specified address is a list with this address encoded as bytes.
+pub fn transfer_to_addressed_transaction_metadatum(
+	address_bytes: &[u8],
+) -> Result<TransactionMetadatum, JsError> {
+	let mut list = MetadataList::new();
+	list.add(&TransactionMetadatum::new_bytes(address_bytes.to_vec())?);
+	Ok(TransactionMetadatum::new_list(&list))
 }
 
-/// Datum containing token transfer data, version 1
-#[derive(Clone, Debug, PartialEq)]
-pub enum TokenTransferDatumV1 {
-	/// User-initiated transfer sent to a specific receiver address
-	UserTransfer {
-		/// Receiving address on the Partner Chain
-		receiver: ByteString,
-	},
-	/// Reserve transfer
-	ReserveTransfer,
-}
-
-impl From<TokenTransferDatumV1> for PlutusData {
-	fn from(datum: TokenTransferDatumV1) -> Self {
-		VersionedGenericDatum {
-			version: 1,
-			datum: PlutusData::new_empty_constr_plutus_data(&0u64.into()),
-			appendix: {
-				match datum {
-					TokenTransferDatumV1::UserTransfer { receiver } => {
-						PlutusData::new_single_value_constr_plutus_data(
-							&0u64.into(),
-							&PlutusData::new_bytes(receiver.0),
-						)
-					},
-					TokenTransferDatumV1::ReserveTransfer => {
-						PlutusData::new_empty_constr_plutus_data(&1u64.into())
-					},
-				}
-			},
-		}
-		.into()
-	}
-}
-
-impl From<TokenTransferDatum> for PlutusData {
-	fn from(datum: TokenTransferDatum) -> Self {
-		match datum {
-			TokenTransferDatum::V1(datum) => datum.into(),
-		}
-	}
-}
-
-impl TryFrom<PlutusData> for TokenTransferDatum {
-	type Error = DataDecodingError;
-	fn try_from(data: PlutusData) -> Result<Self, Self::Error> {
-		Self::decode(&data)
-	}
-}
-
-impl VersionedDatum for TokenTransferDatum {
-	fn decode(data: &PlutusData) -> crate::DecodingResult<Self> {
-		match plutus_data_version_and_payload(data) {
-			None => Err(decoding_error_and_log(data, "TokenTransferDatum", "unversioned datum")),
-			Some(VersionedGenericDatum { appendix, version: 1, .. }) => {
-				decode_v1_token_transfer_datum(&appendix).ok_or_else(|| {
-					decoding_error_and_log(&appendix, "TokenTransferDatum", "malformed appendix")
-				})
-			},
-			Some(_) => Err(decoding_error_and_log(data, "TokenTransferDatum", "invalid version")),
-		}
-	}
-}
-
-fn decode_v1_token_transfer_datum(appendix: &PlutusData) -> Option<TokenTransferDatum> {
-	let constr = appendix.as_constr_plutus_data()?;
-	let alternative = u64::from(constr.alternative());
-	let data = constr.data();
-
-	match alternative {
-		0 if data.len() == 1 => {
-			let receiver = data.get(0).as_bytes()?.into();
-			Some(TokenTransferDatum::V1(TokenTransferDatumV1::UserTransfer { receiver }))
-		},
-		1 if data.is_none_or_empty() => {
-			Some(TokenTransferDatum::V1(TokenTransferDatumV1::ReserveTransfer))
-		},
-		_ => None,
-	}
-}
-
-#[cfg(test)]
-mod tests {
-	use super::*;
-	use crate::test_helpers::test_plutus_data;
-
-	fn reserve_transfer_data() -> PlutusData {
-		test_plutus_data!({
-			"list": [
-				{ "constructor": 0, "fields": [] },
-				{ "constructor": 1, "fields": [] },
-				{ "int":1 },
-
-			]
-		})
-	}
-
-	fn user_transfer_data(addr: &[u8]) -> PlutusData {
-		test_plutus_data!({
-					"list": [
-						{ "constructor": 0, "fields": [] },
-						{ "constructor": 0, "fields": [{ "bytes": hex::encode(addr) }] },
-						{ "int":1 },
-
-					]
-		})
-	}
-
-	mod decode {
-		use super::*;
-		use hex_literal::hex;
-		use pretty_assertions::assert_eq;
-
-		#[test]
-		fn user_transfer_v1() {
-			let datum = TokenTransferDatum::decode(&user_transfer_data(&hex!("abcd")))
-				.expect("Should decode successfully");
-			assert_eq!(
-				datum,
-				TokenTransferDatum::V1(TokenTransferDatumV1::UserTransfer {
-					receiver: ByteString(hex!("abcd").into())
-				})
-			)
-		}
-
-		#[test]
-		fn reserve_transfer_v1() {
-			let datum = TokenTransferDatum::decode(&reserve_transfer_data())
-				.expect("Should decode successfully");
-			assert_eq!(datum, TokenTransferDatum::V1(TokenTransferDatumV1::ReserveTransfer))
-		}
-	}
-
-	mod encode {
-		use super::*;
-		use hex_literal::hex;
-		use pretty_assertions::assert_eq;
-
-		#[test]
-		fn user_transfer_v1() {
-			let data: PlutusData = TokenTransferDatum::V1(TokenTransferDatumV1::UserTransfer {
-				receiver: ByteString::from_hex_unsafe("abcd"),
-			})
-			.into();
-
-			assert_eq!(data, user_transfer_data(&hex!("abcd")))
-		}
-
-		#[test]
-		fn reserve_transfer_v1() {
-			let data: PlutusData =
-				TokenTransferDatum::V1(TokenTransferDatumV1::ReserveTransfer).into();
-
-			assert_eq!(data, reserve_transfer_data())
-		}
-	}
+/// Metadata of reserve transfer is an empty list.
+pub fn transfer_to_reserve_metadatum() -> TransactionMetadatum {
+	TransactionMetadatum::new_list(&MetadataList::new())
 }

--- a/toolkit/utils/db-sync-sqlx/Cargo.toml
+++ b/toolkit/utils/db-sync-sqlx/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 sqlx = { workspace = true }
 sidechain-domain = { workspace = true, features = ["std"] }
 num-traits = { workspace = true }
+hex = { workspace = true }
 
 [lib]
 test = false

--- a/toolkit/utils/db-sync-sqlx/src/lib.rs
+++ b/toolkit/utils/db-sync-sqlx/src/lib.rs
@@ -19,6 +19,7 @@ use sqlx::encode::IsNull;
 use sqlx::error::BoxDynError;
 use sqlx::postgres::PgTypeInfo;
 use sqlx::*;
+use std::fmt::{Debug, Formatter};
 
 /// Macro to handle numeric types that are non-negative but are stored by Db-Sync using
 /// signed SQL types.
@@ -121,8 +122,14 @@ sqlx_implementations_for_wrapper!(i16, "INT2", TxIndex, UtxoIndex);
 pub struct TxIndexInBlock(pub u32);
 sqlx_implementations_for_wrapper!(i32, "INT4", TxIndexInBlock, McTxIndexInBlock);
 
-#[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialOrd, Ord, PartialEq, Eq)]
 pub struct TxHash(pub [u8; 32]);
+
+impl Debug for TxHash {
+	fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+		write!(f, "TxHash(0x{})", hex::encode(self.0))
+	}
+}
 
 impl sqlx::Type<Postgres> for TxHash {
 	fn type_info() -> <Postgres as sqlx::Database>::TypeInfo {


### PR DESCRIPTION
# Description

Updates "token bridge" which is meant to be Cardano to Midnight bridge to use transaction metadata instead of UTXO plutus data as a carrier of information about recipient address.

This would not work with chains that already has bridge enabled, because the "idempotence key" aka data checkpoint has changes from being UTXO to a TX hash.

This is revival of a PR in IOHK repo with some changes: no layer of "version metadatum", simpler metadatum, fixes to Dolos datasource (which could be ignored BTW, because it is not really supported and perhaps it never will be supported).

NOT DONE: pallet event for the indexer- this will come separately as this PR has almost 400 lines already

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] The size limit of 400 LOC isn't needlessly exceeded
- [ ] The PR refers to a JIRA ticket (if one exists)
- [ ] New tests are added if needed and existing tests are updated.
- [ ] New code is documented and existing documentation is updated.
- [ ] Relevant logging and metrics added
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff
