### PR TITLE
Bridge events

### DIFF
--- a/demo/runtime/src/lib.rs
+++ b/demo/runtime/src/lib.rs
@@ -687,6 +687,7 @@ impl pallet_partner_chains_bridge::Config for Runtime {
 	type GovernanceOrigin = EnsureRoot<Runtime>;
 	type Recipient = AccountId;
 	type TransferHandler = TestHelperPallet;
+	type HandlerResult = ();
 	type MaxTransfersPerBlock = MaxTransfersPerBlock;
 	type WeightInfo = ();
 

--- a/demo/runtime/src/test_helper_pallet.rs
+++ b/demo/runtime/src/test_helper_pallet.rs
@@ -14,7 +14,7 @@ pub mod pallet {
 	use sp_block_participation::BlockProductionData;
 	use sp_core::bytes::*;
 	use sp_inherents::IsFatalError;
-	use sp_partner_chains_bridge::BridgeTransferV1;
+	use sp_partner_chains_bridge::{BridgeTransferV1, TransferRecipient};
 
 	type ParticipationData = BlockProductionData<BlockAuthor, DelegatorKey>;
 
@@ -128,19 +128,23 @@ pub mod pallet {
 		}
 	}
 
-	impl<T: Config> pallet_partner_chains_bridge::TransferHandler<AccountId> for Pallet<T> {
-		fn handle_incoming_transfer(transfer: BridgeTransferV1<AccountId>) {
-			match transfer {
-				BridgeTransferV1::InvalidTransfer { token_amount, tx_hash } => {
-					log::warn!("⚠️ Recorded an invalid transfer of {token_amount} (tx {tx_hash})");
+	impl<T: Config> pallet_partner_chains_bridge::TransferHandler<AccountId, ()> for Pallet<T> {
+		fn handle_incoming_transfer(transfer: BridgeTransferV1<AccountId>) -> () {
+			let token_amount = transfer.amount;
+			let mc_tx_hash = transfer.mc_tx_hash;
+			match transfer.recipient {
+				TransferRecipient::Invalid => {
+					log::warn!(
+						"⚠️ Recorded an invalid transfer of {token_amount} (tx {mc_tx_hash})"
+					);
 					TotalInvalidTransfers::<T>::mutate(|v| *v + token_amount);
 				},
-				BridgeTransferV1::UserTransfer { token_amount, recipient } => {
+				TransferRecipient::Address { recipient } => {
 					log::info!("💸 Registered a transfer of {token_amount} to {recipient:?}");
 					let _ = Balances::deposit_creating(&recipient, token_amount.into());
 					UserTransferTotals::<T>::mutate(recipient, |v| *v += token_amount);
 				},
-				BridgeTransferV1::ReserveTransfer { token_amount } => {
+				TransferRecipient::Reserve => {
 					log::info!("🏦 Registered a reserve transfer of {token_amount}.");
 					let _ =
 						Balances::deposit_creating(&T::ReserveAccount::get(), token_amount.into());

--- a/e2e-tests/src/substrate_api.py
+++ b/e2e-tests/src/substrate_api.py
@@ -955,7 +955,6 @@ class SubstrateApi(BlockchainApi):
             mc_block = self.get_mc_block_by_block_hash(mc_hash).block_no
             logger.debug(f"Main chain reference block: {mc_block}")
 
-            token_transfer_value = None
             block = self.substrate.get_block(block_number=block_no)
             for idx, extrinsic in enumerate(block["extrinsics"]):
                 logger.debug(f"# {idx}: {extrinsic.value}")
@@ -967,6 +966,7 @@ class SubstrateApi(BlockchainApi):
                     transfers = next((arg["value"] for arg in call_args if arg["name"] == "transfers"), [])
                     transfer_values = Counter()
                     for transfer in transfers:
+                        logger.error(f"# {transfer}")
                         for transfer_type, fields in transfer.items():
                             match transfer_type:
                                 case "ReserveTransfer":

--- a/e2e-tests/src/substrate_api.py
+++ b/e2e-tests/src/substrate_api.py
@@ -966,18 +966,17 @@ class SubstrateApi(BlockchainApi):
                     transfers = next((arg["value"] for arg in call_args if arg["name"] == "transfers"), [])
                     transfer_values = Counter()
                     for transfer in transfers:
-                        for _type, fields in transfer.items():
-                            amount = fields["amount"]
-                            recipient_type, recipient = fields["recipient"]
-                            match recipient_type:
-                                case "Reserve":
-                                    transfer_values["reserve"] += amount
-                                case "Address":
-                                    transfer_values[recipient["recipient"]] += amount
-                                case "Invalid":
-                                    transfer_values["invalid"] += amount
-                                case _:
-                                    logger.error(f"Invalid recipient type in bridge inherent: {recipient_type}")
+                        amount = transfer["amount"]
+                        recipient = transfer["recipient"]
+                        match recipient:
+                            case "Reserve":
+                                transfer_values["reserve"] += amount
+                            case "Address", fields:
+                                transfer_values[fields["recipient"]] += amount
+                            case "Invalid":
+                                transfer_values["invalid"] += amount
+                            case _:
+                                logger.error(f"Invalid recipient in bridge inherent: {recipient}")
 
                         if transfer_values:
                             return transfer_values

--- a/e2e-tests/src/substrate_api.py
+++ b/e2e-tests/src/substrate_api.py
@@ -966,17 +966,18 @@ class SubstrateApi(BlockchainApi):
                     transfers = next((arg["value"] for arg in call_args if arg["name"] == "transfers"), [])
                     transfer_values = Counter()
                     for transfer in transfers:
-                        logger.error(f"# {transfer}")
-                        for transfer_type, fields in transfer.items():
-                            match transfer_type:
-                                case "ReserveTransfer":
-                                    transfer_values["reserve"] += fields["token_amount"]
-                                case "UserTransfer":
-                                    transfer_values[fields["recipient"]] += fields["token_amount"]
-                                case "InvalidTransfer":
-                                    transfer_values["invalid"] += fields["token_amount"]
+                        for _type, fields in transfer.items():
+                            amount = fields["amount"]
+                            recipient_type, recipient = fields["recipient"]
+                            match recipient_type:
+                                case "Reserve":
+                                    transfer_values["reserve"] += amount
+                                case "Address":
+                                    transfer_values[recipient["recipient"]] += amount
+                                case "Invalid":
+                                    transfer_values["invalid"] += amount
                                 case _:
-                                    logger.error(f"Invalid transfer type in bridge inherent: {transfer_type}")
+                                    logger.error(f"Invalid recipient type in bridge inherent: {recipient_type}")
 
                         if transfer_values:
                             return transfer_values

--- a/toolkit/bridge/pallet/src/benchmarking.rs
+++ b/toolkit/bridge/pallet/src/benchmarking.rs
@@ -25,15 +25,17 @@ where
 	T::Recipient: UncheckedFrom<H256>,
 {
 	fn transfers(t: u32) -> BoundedVec<BridgeTransferV1<T::Recipient>, T::MaxTransfersPerBlock> {
-		use BridgeTransferV1::*;
-
 		let recipient = T::Recipient::unchecked_from(Default::default());
-		let tx_hash = McTxHash::default();
+		let mc_tx_hash = McTxHash::default();
 
 		let transfers = alloc::vec![
-			UserTransfer { token_amount: 1000, recipient },
-			ReserveTransfer { token_amount: 1000 },
-			InvalidTransfer { token_amount: 1000, tx_hash },
+			BridgeTransferV1 {
+				amount: 1000,
+				mc_tx_hash,
+				recipient: TransferRecipient::Address { recipient }
+			},
+			BridgeTransferV1 { amount: 1000, mc_tx_hash, recipient: TransferRecipient::Reserve },
+			BridgeTransferV1 { amount: 1000, mc_tx_hash, recipient: TransferRecipient::Invalid },
 		]
 		.into_iter()
 		.cycle()

--- a/toolkit/bridge/pallet/src/lib.rs
+++ b/toolkit/bridge/pallet/src/lib.rs
@@ -202,18 +202,19 @@ use sp_partner_chains_bridge::BridgeTransferV1;
 /// ledger structure. Calls to all functions defined by this trait should not return any errors
 /// as this would fail the block creation. Instead, any validation and business logic errors
 /// should be handled gracefully inside the handler code.
-pub trait TransferHandler<Recipient> {
+pub trait TransferHandler<Recipient, HandlerResult> {
 	/// Should handle an incoming token transfer of `token_mount` tokens to `recipient`
-	fn handle_incoming_transfer(_transfer: BridgeTransferV1<Recipient>);
+	fn handle_incoming_transfer(transfer: BridgeTransferV1<Recipient>) -> HandlerResult;
 }
 
 /// No-op implementation of `TransferHandler` for unit type.
-impl<Recipient> TransferHandler<Recipient> for () {
-	fn handle_incoming_transfer(_transfer: BridgeTransferV1<Recipient>) {}
+impl<Recipient> TransferHandler<Recipient, ()> for () {
+	fn handle_incoming_transfer(_transfer: BridgeTransferV1<Recipient>) -> () {}
 }
 
 #[frame_support::pallet]
 pub mod pallet {
+
 	use super::*;
 	use crate::weights::WeightInfo;
 	use frame_system::{
@@ -224,7 +225,7 @@ pub mod pallet {
 	use sidechain_domain::McTxHash;
 	use sp_partner_chains_bridge::{
 		BridgeDataCheckpoint, INHERENT_IDENTIFIER, InherentError, MainChainScripts,
-		TokenBridgeTransfersV1,
+		TokenBridgeTransfersV1, TransferRecipient,
 	};
 
 	/// Current version of the pallet
@@ -243,8 +244,11 @@ pub mod pallet {
 		/// Transfer recipient
 		type Recipient: Member + Parameter + MaxEncodedLen;
 
+		/// User defined handler returns this type. Values are attached to pallet events.
+		type HandlerResult: Member + Parameter + MaxEncodedLen;
+
 		/// Handler for incoming token transfers
-		type TransferHandler: TransferHandler<Self::Recipient>;
+		type TransferHandler: TransferHandler<Self::Recipient, Self::HandlerResult>;
 
 		/// Maximum number of transfers that can be handled in one block for each transfer type
 		type MaxTransfersPerBlock: Get<u32>;
@@ -255,6 +259,22 @@ pub mod pallet {
 		/// Benchmark helper type used for running benchmarks
 		#[cfg(feature = "runtime-benchmarks")]
 		type BenchmarkHelper: benchmarking::BenchmarkHelper<Self>;
+	}
+
+	#[pallet::event]
+	#[pallet::generate_deposit(pub (super) fn deposit_event)]
+	pub enum Event<T: Config> {
+		/// For each handled transfer this event is emitted
+		Transfer {
+			/// Main chain transaction hash for correlation of PC with MC
+			mc_tx_hash: McTxHash,
+			/// Amount of tokens that were transferred
+			amount: u64,
+			/// Handler specific infomation passed to the event
+			result: <T as Config>::HandlerResult,
+			/// Beneficiary of the transfer
+			recipient: TransferRecipient<<T as Config>::Recipient>,
+		},
 	}
 
 	/// Error type used by the pallet's extrinsics
@@ -324,8 +344,14 @@ pub mod pallet {
 			ensure_none(origin)?;
 			ensure!(!InherentExecutedThisBlock::<T>::get(), Error::<T>::InherentAlreadyExecuted);
 			InherentExecutedThisBlock::<T>::put(true);
-			for transfer in transfers {
-				T::TransferHandler::handle_incoming_transfer(transfer);
+			for transfer in transfers.into_iter() {
+				let result = T::TransferHandler::handle_incoming_transfer(transfer.clone());
+				Self::deposit_event(Event::Transfer {
+					mc_tx_hash: transfer.mc_tx_hash,
+					amount: transfer.amount,
+					result,
+					recipient: transfer.recipient,
+				})
 			}
 			DataCheckpoint::<T>::put(data_checkpoint);
 			Ok(())

--- a/toolkit/bridge/pallet/src/mock.rs
+++ b/toolkit/bridge/pallet/src/mock.rs
@@ -34,9 +34,10 @@ pub mod mock_pallet {
 	#[pallet::unbounded]
 	pub type Transfers<T: Config> = StorageValue<_, Vec<BridgeTransferV1<RecipientAddress>>>;
 
-	impl<T> TransferHandler<RecipientAddress> for Pallet<T> {
-		fn handle_incoming_transfer(transfer: BridgeTransferV1<RecipientAddress>) {
-			Transfers::<Test>::append(transfer);
+	impl<T> TransferHandler<RecipientAddress, u64> for Pallet<T> {
+		fn handle_incoming_transfer(transfer: BridgeTransferV1<RecipientAddress>) -> u64 {
+			Transfers::<Test>::append(transfer.clone());
+			transfer.amount / 10
 		}
 	}
 }
@@ -87,6 +88,7 @@ impl frame_system::Config for Test {
 impl crate::Config for Test {
 	type GovernanceOrigin = EnsureRoot<AccountId>;
 	type Recipient = RecipientAddress;
+	type HandlerResult = u64;
 	type TransferHandler = Mock;
 	type MaxTransfersPerBlock = MaxTransfersPerBlock;
 	type WeightInfo = ();

--- a/toolkit/bridge/pallet/src/tests.rs
+++ b/toolkit/bridge/pallet/src/tests.rs
@@ -1,7 +1,7 @@
 use crate::mock::*;
 use crate::pallet::Call;
 use crate::*;
-use BridgeTransferV1::*;
+use TransferRecipient::*;
 use core::str::FromStr;
 use frame_support::{
 	assert_err, assert_ok,
@@ -14,9 +14,13 @@ use sp_runtime::{AccountId32, BoundedVec};
 
 fn transfers() -> BoundedVec<BridgeTransferV1<RecipientAddress>, MaxTransfersPerBlock> {
 	bounded_vec![
-		UserTransfer { token_amount: 100, recipient: AccountId32::new([2; 32]) },
-		ReserveTransfer { token_amount: 200 },
-		InvalidTransfer { token_amount: 300, tx_hash: McTxHash([1; 32]) }
+		BridgeTransferV1 {
+			amount: 100,
+			recipient: Address { recipient: AccountId32::new([2; 32]) },
+			mc_tx_hash: McTxHash([1; 32])
+		},
+		BridgeTransferV1 { amount: 200, mc_tx_hash: McTxHash([2; 32]), recipient: Reserve },
+		BridgeTransferV1 { amount: 300, mc_tx_hash: McTxHash([3; 32]), recipient: Invalid }
 	]
 }
 
@@ -70,6 +74,34 @@ mod handle_transfers {
 	}
 
 	#[test]
+	fn emits_events() {
+		new_test_ext().execute_with(|| {
+			// Frame system drops events from block 0.
+			frame_system::Pallet::<Test>::set_block_number(1);
+			assert_ok!(Bridge::handle_transfers(
+				RuntimeOrigin::none(),
+				transfers(),
+				data_checkpoint()
+			));
+
+			let events: Vec<_> =
+				frame_system::Pallet::<Test>::events().into_iter().map(|e| e.event).collect();
+			let expected: Vec<<mock::Test as frame_system::Config>::RuntimeEvent> = transfers()
+				.into_iter()
+				.map(|t| {
+					mock::RuntimeEvent::Bridge(Event::Transfer {
+						mc_tx_hash: t.mc_tx_hash,
+						amount: t.amount,
+						result: t.amount / 10,
+						recipient: t.recipient,
+					})
+				})
+				.collect();
+			assert_eq!(events, expected);
+		})
+	}
+
+	#[test]
 	fn updates_the_data_checkpoint() {
 		new_test_ext().execute_with(|| {
 			assert_ok!(Bridge::handle_transfers(
@@ -100,6 +132,51 @@ mod handle_transfers {
 			);
 		})
 	}
+
+	// #[test]
+	// fn duplicate_inherent_protection_works() {
+	// 	new_test_ext().execute_with(|| {
+	// 		init_ledger_state();
+	// 		let (cardano_reward_address, dust_public_key) = test_wallet_pairing();
+
+	// 		let utxos = vec![ObservedUtxo {
+	// 			header: test_header(1, 2, 0, None),
+	// 			data: ObservedUtxoData::Registration(RegistrationData {
+	// 				cardano_reward_address,
+	// 				dust_public_key: dust_public_key.clone(),
+	// 			}),
+	// 		}];
+
+	// 		// First call succeeds
+	// 		let inherent_data = create_inherent(utxos.clone(), test_position(3, 0));
+	// 		let call = CNightObservation::create_inherent(&inherent_data).unwrap();
+	// 		assert_ok!(RuntimeCall::CNightObservation(call).dispatch(RawOrigin::None.into()));
+
+	// 		// Second call in same block fails
+	// 		let call2 = Call::process_tokens {
+	// 			utxos: utxos.clone(),
+	// 			next_cardano_position: test_position(3, 0),
+	// 		};
+	// 		assert_noop!(
+	// 			RuntimeCall::CNightObservation(call2).dispatch(RawOrigin::None.into()),
+	// 			Error::<Test>::InherentAlreadyExecuted
+	// 		);
+
+	// 		advance_block_and_reset_events();
+
+	// 		// Third call in new block succeeds
+	// 		let utxos2 = vec![ObservedUtxo {
+	// 			header: test_header(4, 0, 0, None),
+	// 			data: ObservedUtxoData::Registration(RegistrationData {
+	// 				cardano_reward_address,
+	// 				dust_public_key,
+	// 			}),
+	// 		}];
+	// 		let inherent_data2 = create_inherent(utxos2, test_position(5, 0));
+	// 		let call3 = CNightObservation::create_inherent(&inherent_data2).unwrap();
+	// 		assert_ok!(RuntimeCall::CNightObservation(call3).dispatch(RawOrigin::None.into()));
+	// 	});
+	// }
 }
 
 mod provide_inherent {

--- a/toolkit/bridge/primitives/src/lib.rs
+++ b/toolkit/bridge/primitives/src/lib.rs
@@ -206,28 +206,29 @@ impl MainChainScripts {
 #[derive(
 	Clone, Debug, Encode, Decode, DecodeWithMemTracking, TypeInfo, PartialEq, Eq, MaxEncodedLen,
 )]
-pub enum BridgeTransferV1<RecipientAddress> {
-	/// Token transfer initiated by a user on Cardano
-	UserTransfer {
-		/// Amount of tokens tranfered
-		token_amount: u64,
-		/// Transfer recipient on the Partner Chain
+pub struct BridgeTransferV1<RecipientAddress> {
+	/// Cardano transaction for this transfer
+	pub mc_tx_hash: McTxHash,
+	/// Amount of tokens tranfered
+	pub amount: u64,
+	/// Transfer recipient on the Partner Chain
+	pub recipient: TransferRecipient<RecipientAddress>,
+}
+
+/// Details of bridge transfer recipient
+#[derive(
+	Clone, Debug, Encode, Decode, DecodeWithMemTracking, TypeInfo, PartialEq, Eq, MaxEncodedLen,
+)]
+pub enum TransferRecipient<RecipientAddress> {
+	/// Transfer to the specified recipient address
+	Address {
+		/// Address of the transfer recipient
 		recipient: RecipientAddress,
 	},
-	/// Token transfer carrying reserve funds being moved from Cardano to the Partner Chain
-	ReserveTransfer {
-		/// Amount of tokens tranfered
-		token_amount: u64,
-	},
-	/// Invalid transfer coming from a Transaction on Cardano that does not contain a metadata that can be
-	/// correctly interpreted. These transfers can either be ignored and considered lost or recovered
-	/// through some custom mechanism.
-	InvalidTransfer {
-		/// Amount of tokens tranfered
-		token_amount: u64,
-		/// ID of the UTXO containing an invalid transfer
-		tx_hash: sidechain_domain::McTxHash,
-	},
+	/// Transfer to the reserve
+	Reserve,
+	/// Invalid transfer. Amount was deposited but kind designation / recipient was not encoded properly
+	Invalid,
 }
 
 /// Structure representing all token bridge transfers incoming from Cardano that are to be

--- a/toolkit/data-sources/db-sync/src/bridge/mod.rs
+++ b/toolkit/data-sources/db-sync/src/bridge/mod.rs
@@ -143,23 +143,24 @@ fn tx_to_transfer<RecipientAddress>(tx: BridgeTx) -> BridgeTransferV1<RecipientA
 where
 	RecipientAddress: for<'a> TryFrom<&'a [u8]>,
 {
-	let token_amount = tx.amount.0.try_into().expect("There can't be more than u64 of cNIGHT");
-	let tx_hash = tx.tx_id();
-	match tx.c2m_metadata {
+	let amount = tx.amount.0.try_into().expect("There can't be more than u64 of cNIGHT");
+	let mc_tx_hash = tx.tx_id();
+	let recipient = match tx.c2m_metadata {
 		Some(JsonValue::Array(values)) => match values.first() {
-			None => BridgeTransferV1::ReserveTransfer { token_amount },
+			None => TransferRecipient::Reserve,
 			Some(JsonValue::String(str)) => {
 				let str = str.trim_start_matches("0x");
 				match hex::decode(str)
 					.ok()
 					.and_then(|bytes| RecipientAddress::try_from(&bytes).ok())
 				{
-					Some(recipient) => BridgeTransferV1::UserTransfer { token_amount, recipient },
-					None => BridgeTransferV1::InvalidTransfer { token_amount, tx_hash },
+					Some(recipient) => TransferRecipient::Address { recipient },
+					None => TransferRecipient::Invalid,
 				}
 			},
-			_ => BridgeTransferV1::InvalidTransfer { token_amount, tx_hash },
+			_ => TransferRecipient::Invalid,
 		},
-		_ => BridgeTransferV1::InvalidTransfer { token_amount, tx_hash },
-	}
+		_ => TransferRecipient::Invalid,
+	};
+	BridgeTransferV1 { mc_tx_hash, amount, recipient }
 }

--- a/toolkit/data-sources/db-sync/src/bridge/tests.rs
+++ b/toolkit/data-sources/db-sync/src/bridge/tests.rs
@@ -1,3 +1,5 @@
+extern crate alloc;
+
 use crate::bridge::cache::CachedTokenBridgeDataSourceImpl;
 use crate::{BlockDataSourceImpl, DbSyncBlockDataSourceConfig, TokenBridgeDataSourceImpl};
 use hex_literal::hex;
@@ -8,6 +10,7 @@ use sidechain_domain::{
 };
 use sp_partner_chains_bridge::{
 	BridgeDataCheckpoint, BridgeTransferV1, MainChainScripts, TokenBridgeDataSource,
+	TransferRecipient,
 };
 use sqlx::PgPool;
 use std::str::FromStr;
@@ -46,37 +49,48 @@ fn init_ics_tx_hash() -> McTxHash {
 }
 
 fn reserve_transfer() -> BridgeTransferV1<ByteString> {
-	BridgeTransferV1::<ByteString>::ReserveTransfer { token_amount: 100 }
+	BridgeTransferV1 {
+		amount: 100,
+		mc_tx_hash: reserve_transfer_tx(),
+		recipient: TransferRecipient::Reserve,
+	}
 }
 
 fn user_transfer_1() -> BridgeTransferV1<ByteString> {
-	BridgeTransferV1::UserTransfer {
+	BridgeTransferV1 {
 		// user transfer 1 consumes utxo from reserve transfer
-		token_amount: 110 - 100,
-		recipient: ByteString(hex!("abcd").to_vec()),
+		amount: 110 - 100,
+		recipient: TransferRecipient::Address { recipient: ByteString(hex!("abcd").to_vec()) },
+		mc_tx_hash: user_transfer_1_tx(),
 	}
 }
 
 fn user_transfer_2() -> BridgeTransferV1<ByteString> {
-	BridgeTransferV1::UserTransfer {
+	BridgeTransferV1 {
 		// user transfer 2 consumes utxo from user transfer 1
-		token_amount: 120 - 110,
-		recipient: ByteString(hex!("1234").to_vec()),
+		amount: 120 - 110,
+		recipient: TransferRecipient::Address { recipient: ByteString(hex!("1234").to_vec()) },
+		mc_tx_hash: user_transfer_2_tx(),
 	}
 }
 
 // transfer with invalid datum
 fn invalid_transfer_1() -> BridgeTransferV1<ByteString> {
-	BridgeTransferV1::InvalidTransfer {
+	BridgeTransferV1 {
 		// invalid transfer consumes utxo from user transfer 2
-		token_amount: 1000 - 120,
-		tx_hash: invalid_transfer_1_tx(),
+		amount: 1000 - 120,
+		mc_tx_hash: invalid_transfer_1_tx(),
+		recipient: TransferRecipient::Invalid,
 	}
 }
 
 // transfer with no datum
 fn invalid_transfer_2() -> BridgeTransferV1<ByteString> {
-	BridgeTransferV1::InvalidTransfer { token_amount: 1000, tx_hash: invalid_transfer_2_tx() }
+	BridgeTransferV1 {
+		amount: 1000,
+		mc_tx_hash: invalid_transfer_2_tx(),
+		recipient: TransferRecipient::Invalid,
+	}
 }
 
 fn reserve_transfer_tx() -> McTxHash {
@@ -85,6 +99,10 @@ fn reserve_transfer_tx() -> McTxHash {
 
 fn user_transfer_1_tx() -> McTxHash {
 	McTxHash(hex!("c000000000000000000000000000000000000000000000000000000000000003"))
+}
+
+fn user_transfer_2_tx() -> McTxHash {
+	McTxHash(hex!("c000000000000000000000000000000000000000000000000000000000000004"))
 }
 
 fn invalid_transfer_1_tx() -> McTxHash {

--- a/toolkit/partner-chains-cli/src/tests/runtime.rs
+++ b/toolkit/partner-chains-cli/src/tests/runtime.rs
@@ -115,6 +115,7 @@ impl pallet_partner_chains_bridge::Config for MockRuntime {
 	type GovernanceOrigin = EnsureRoot<MockRuntime>;
 	type Recipient = AccountId32;
 	type TransferHandler = ();
+	type HandlerResult = ();
 	type MaxTransfersPerBlock = ConstU32<3>;
 	type WeightInfo = ();
 	#[cfg(feature = "runtime-benchmarks")]


### PR DESCRIPTION
# Description

For midnight indexer pallet events are required.
Additional `HandlerResult` type is added to the pallet config, because we ought to pass Midnight Tx Hash in these events.
I think we cannot really deposit events from the handler (to be checked).